### PR TITLE
fix: refresh repoInfo/tagInfo/releaseInfo after 30-day staleness

### DIFF
--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -213,6 +213,46 @@ function Get-RepoPriorityScore {
             $score += 10
         }
     }
+
+    # Stale repoInfo/tagInfo/releaseInfo checks — boost priority when data exists
+    # but was never timestamped or hasn't been refreshed in over 30 days.
+    if ($hasRepoInfo -and $action.repoInfo.updated_at) {
+        $hasCheckedAt = Get-Member -inputobject $action.repoInfo -name "checkedAt" -Membertype Properties
+        if (!$hasCheckedAt -or !$action.repoInfo.checkedAt) {
+            $score += 45  # has repoInfo but no checkedAt — was never refreshed
+        } else {
+            $daysSinceCheck = ((Get-Date) - [datetime]$action.repoInfo.checkedAt).Days
+            if ($daysSinceCheck -gt 30) {
+                $score += 45
+            }
+        }
+    }
+
+    $hasTagInfoCheckedAt = Get-Member -inputobject $action -name "tagInfoCheckedAt" -Membertype Properties
+    $hasTagInfo = Get-Member -inputobject $action -name "tagInfo" -Membertype Properties
+    if ($hasTagInfo -and $action.tagInfo) {
+        if (!$hasTagInfoCheckedAt -or !$action.tagInfoCheckedAt) {
+            $score += 15
+        } else {
+            $daysSinceCheck = ((Get-Date) - [datetime]$action.tagInfoCheckedAt).Days
+            if ($daysSinceCheck -gt 30) {
+                $score += 15
+            }
+        }
+    }
+
+    $hasReleaseInfoCheckedAt = Get-Member -inputobject $action -name "releaseInfoCheckedAt" -Membertype Properties
+    $hasReleaseInfo = Get-Member -inputobject $action -name "releaseInfo" -Membertype Properties
+    if ($hasReleaseInfo -and $action.releaseInfo) {
+        if (!$hasReleaseInfoCheckedAt -or !$action.releaseInfoCheckedAt) {
+            $score += 15
+        } else {
+            $daysSinceCheck = ((Get-Date) - [datetime]$action.releaseInfoCheckedAt).Days
+            if ($daysSinceCheck -gt 30) {
+                $score += 15
+            }
+        }
+    }
     
     return $score
 }
@@ -1527,8 +1567,17 @@ function GetMoreInfo {
             ($owner, $repo) = GetOrgActionInfo($action.name)
 
             $hasField = Get-Member -inputobject $action -name "repoInfo" -Membertype Properties
-            if (!$hasField -or ($null -eq $action.actionType.actionType) -or ($hasField -and ($null -eq $action.repoInfo.updated_at))) {
-                Write-Host "$i/$max - Checking extended action information for [$forkOrg/$($action.name)]. hasField: [$($null -ne $hasField)], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
+            $repoInfoStale = $false
+            if ($hasField -and $action.repoInfo.updated_at) {
+                $hasCheckedAt = Get-Member -inputobject $action.repoInfo -name "checkedAt" -Membertype Properties
+                if (!$hasCheckedAt -or !$action.repoInfo.checkedAt) {
+                    $repoInfoStale = $true  # existing data with no timestamp — treat as stale
+                } else {
+                    $repoInfoStale = ((Get-Date) - [datetime]$action.repoInfo.checkedAt).Days -gt 30
+                }
+            }
+            if (!$hasField -or ($null -eq $action.actionType.actionType) -or ($hasField -and ($null -eq $action.repoInfo.updated_at)) -or $repoInfoStale) {
+                Write-Host "$i/$max - Checking extended action information for [$forkOrg/$($action.name)]. hasField: [$($null -ne $hasField)], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)], stale: [$repoInfoStale]"
                 try {
                     ($repo_archived, $repo_disabled, $repo_updated_at, $latest_release_published_at, $statusCode) = GetRepoInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
                     if ($statusCode -and ($statusCode -eq "NotFound")) {
@@ -1551,6 +1600,7 @@ function GetMoreInfo {
                                 disabled = $repo_disabled
                                 updated_at = $repo_updated_at
                                 latest_release_published_at = $latest_release_published_at
+                                checkedAt = Get-Date
                             }
 
                             $action | Add-Member -Name repoInfo -Value $repoInfo -MemberType NoteProperty
@@ -1563,6 +1613,12 @@ function GetMoreInfo {
                             $action.repoInfo.disabled = $repo_disabled
                             $action.repoInfo.updated_at = $repo_updated_at
                             $action.repoInfo.latest_release_published_at = $latest_release_published_at
+                            $checkedAtField = Get-Member -InputObject $action.repoInfo -Name "checkedAt" -MemberType Properties
+                            if (-not $checkedAtField) {
+                                $action.repoInfo | Add-Member -Name checkedAt -Value (Get-Date) -MemberType NoteProperty
+                            } else {
+                                $action.repoInfo.checkedAt = Get-Date
+                            }
                             $memberUpdate++ | Out-Null
                         }
                     }
@@ -1607,7 +1663,16 @@ function GetMoreInfo {
             }
 
             $hasField = Get-Member -inputobject $action -name "tagInfo" -Membertype Properties
-            if (!$hasField -or ($null -eq $action.tagInfo)) {
+            $tagInfoCheckedAtField = Get-Member -inputobject $action -name "tagInfoCheckedAt" -Membertype Properties
+            $tagInfoStale = $false
+            if ($hasField -and $action.tagInfo) {
+                if (!$tagInfoCheckedAtField -or !$action.tagInfoCheckedAt) {
+                    $tagInfoStale = $true  # existing data with no timestamp — treat as stale
+                } else {
+                    $tagInfoStale = ((Get-Date) - [datetime]$action.tagInfoCheckedAt).Days -gt 30
+                }
+            }
+            if (!$hasField -or ($null -eq $action.tagInfo) -or $tagInfoStale) {
                 #Write-Host "$i/$max - Checking tag information for [$forkOrg/$($action.name)]. hasField: [$hasField], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
                 try {
                     $tagInfo = GetRepoTagInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
@@ -1620,6 +1685,11 @@ function GetMoreInfo {
                     else {
                         #Write-Host "Updating tag information object with tags:[$($tagInfo.Length)]"
                         $action.tagInfo = $tagInfo
+                    }
+                    if (!$tagInfoCheckedAtField) {
+                        $action | Add-Member -Name tagInfoCheckedAt -Value (Get-Date) -MemberType NoteProperty
+                    } else {
+                        $action.tagInfoCheckedAt = Get-Date
                     }
                 }
                 catch {
@@ -1649,7 +1719,16 @@ function GetMoreInfo {
             }
 
             $hasField = Get-Member -inputobject $action -name "releaseInfo" -Membertype Properties
-            if (!$hasField -or ($null -eq $action.releaseInfo)) {
+            $releaseInfoCheckedAtField = Get-Member -inputobject $action -name "releaseInfoCheckedAt" -Membertype Properties
+            $releaseInfoStale = $false
+            if ($hasField -and $action.releaseInfo) {
+                if (!$releaseInfoCheckedAtField -or !$action.releaseInfoCheckedAt) {
+                    $releaseInfoStale = $true  # existing data with no timestamp — treat as stale
+                } else {
+                    $releaseInfoStale = ((Get-Date) - [datetime]$action.releaseInfoCheckedAt).Days -gt 30
+                }
+            }
+            if (!$hasField -or ($null -eq $action.releaseInfo) -or $releaseInfoStale) {
                 #Write-Host "$i/$max - Checking release information for [$forkOrg/$($action.name)]. hasField: [$hasField], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
                 try {
                     $releaseInfo = GetRepoReleases -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
@@ -1662,6 +1741,11 @@ function GetMoreInfo {
                     else {
                         #Write-Host "Updating release information object with releases:[$($releaseInfo.Length)]"
                         $action.releaseInfo = $releaseInfo
+                    }
+                    if (!$releaseInfoCheckedAtField) {
+                        $action | Add-Member -Name releaseInfoCheckedAt -Value (Get-Date) -MemberType NoteProperty
+                    } else {
+                        $action.releaseInfoCheckedAt = Get-Date
                     }
                 }
                 catch {

--- a/tests/repoInfo-prioritization.Tests.ps1
+++ b/tests/repoInfo-prioritization.Tests.ps1
@@ -56,6 +56,46 @@ BeforeAll {
                 $score += 10
             }
         }
+
+        # Stale repoInfo/tagInfo/releaseInfo checks — boost priority when data exists
+        # but was never timestamped or hasn't been refreshed in over 30 days.
+        if ($hasRepoInfo -and $action.repoInfo.updated_at) {
+            $hasCheckedAt = Get-Member -inputobject $action.repoInfo -name "checkedAt" -Membertype Properties
+            if (!$hasCheckedAt -or !$action.repoInfo.checkedAt) {
+                $score += 45  # has repoInfo but no checkedAt — was never refreshed
+            } else {
+                $daysSinceCheck = ((Get-Date) - [datetime]$action.repoInfo.checkedAt).Days
+                if ($daysSinceCheck -gt 30) {
+                    $score += 45
+                }
+            }
+        }
+
+        $hasTagInfoCheckedAt = Get-Member -inputobject $action -name "tagInfoCheckedAt" -Membertype Properties
+        $hasTagInfo = Get-Member -inputobject $action -name "tagInfo" -Membertype Properties
+        if ($hasTagInfo -and $action.tagInfo) {
+            if (!$hasTagInfoCheckedAt -or !$action.tagInfoCheckedAt) {
+                $score += 15
+            } else {
+                $daysSinceCheck = ((Get-Date) - [datetime]$action.tagInfoCheckedAt).Days
+                if ($daysSinceCheck -gt 30) {
+                    $score += 15
+                }
+            }
+        }
+
+        $hasReleaseInfoCheckedAt = Get-Member -inputobject $action -name "releaseInfoCheckedAt" -Membertype Properties
+        $hasReleaseInfo = Get-Member -inputobject $action -name "releaseInfo" -Membertype Properties
+        if ($hasReleaseInfo -and $action.releaseInfo) {
+            if (!$hasReleaseInfoCheckedAt -or !$action.releaseInfoCheckedAt) {
+                $score += 15
+            } else {
+                $daysSinceCheck = ((Get-Date) - [datetime]$action.releaseInfoCheckedAt).Days
+                if ($daysSinceCheck -gt 30) {
+                    $score += 15
+                }
+            }
+        }
         
         return $score
     }
@@ -126,8 +166,13 @@ Describe "Get-RepoPriorityScore" {
             }
             repoInfo = [PSCustomObject]@{
                 updated_at = Get-Date
+                checkedAt  = Get-Date
             }
             repoSize = 100
+            tagInfo = @(@{ tag = "v1.0.0"; sha = "abc" })
+            tagInfoCheckedAt = Get-Date
+            releaseInfo = @(@{ tag_name = "v1.0.0"; target_commitish = "main" })
+            releaseInfoCheckedAt = Get-Date
             dependents = [PSCustomObject]@{
                 dependents = 50
                 dependentsLastUpdated = Get-Date
@@ -156,6 +201,7 @@ Describe "Get-RepoPriorityScore" {
             }
             repoInfo = [PSCustomObject]@{
                 updated_at = Get-Date
+                checkedAt  = Get-Date
             }
             repoSize = 100
             dependents = [PSCustomObject]@{
@@ -187,6 +233,7 @@ Describe "Get-RepoPriorityScore" {
             }
             repoInfo = [PSCustomObject]@{
                 updated_at = Get-Date
+                checkedAt  = Get-Date
             }
             repoSize = 100
             dependents = [PSCustomObject]@{
@@ -205,13 +252,142 @@ Describe "Get-RepoPriorityScore" {
         $score | Should -BeGreaterThan 0
         $score | Should -BeLessOrEqual 10
     }
+
+    It "Should add score for repoInfo missing checkedAt (legacy data)" {
+        # Arrange — simulates an action that was populated before checkedAt was introduced
+        $action = [PSCustomObject]@{
+            name = "test-action"
+            owner = "test-owner"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = "2022-01-01T00:00:00Z" }  # no checkedAt
+            repoSize = 100
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+
+        # Act
+        $score = Get-RepoPriorityScore -action $action
+
+        # Assert
+        $score | Should -Be 45
+    }
+
+    It "Should add score for repoInfo with stale checkedAt (>30 days old)" {
+        # Arrange
+        $oldDate = (Get-Date).AddDays(-45)
+        $action = [PSCustomObject]@{
+            name = "test-action"
+            owner = "test-owner"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = "2022-01-01T00:00:00Z"; checkedAt = $oldDate }
+            repoSize = 100
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+
+        # Act
+        $score = Get-RepoPriorityScore -action $action
+
+        # Assert
+        $score | Should -Be 45
+    }
+
+    It "Should not add stale score for repoInfo checked within 30 days" {
+        # Arrange
+        $recentDate = (Get-Date).AddDays(-15)
+        $action = [PSCustomObject]@{
+            name = "test-action"
+            owner = "test-owner"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = "2022-01-01T00:00:00Z"; checkedAt = $recentDate }
+            repoSize = 100
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+
+        # Act
+        $score = Get-RepoPriorityScore -action $action
+
+        # Assert
+        $score | Should -Be 0
+    }
+
+    It "Should add score for tagInfo missing tagInfoCheckedAt (legacy data)" {
+        # Arrange
+        $action = [PSCustomObject]@{
+            name = "test-action"
+            owner = "test-owner"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }
+            repoSize = 100
+            tagInfo = @(@{ tag = "v1.0.0"; sha = "abc" })  # no tagInfoCheckedAt
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+
+        # Act
+        $score = Get-RepoPriorityScore -action $action
+
+        # Assert
+        $score | Should -Be 15
+    }
+
+    It "Should add score for releaseInfo missing releaseInfoCheckedAt (legacy data)" {
+        # Arrange
+        $action = [PSCustomObject]@{
+            name = "test-action"
+            owner = "test-owner"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }
+            repoSize = 100
+            releaseInfo = @(@{ tag_name = "v1.0.0"; target_commitish = "main" })  # no releaseInfoCheckedAt
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+
+        # Act
+        $score = Get-RepoPriorityScore -action $action
+
+        # Assert
+        $score | Should -Be 15
+    }
+
+    It "Should add combined score for stale tagInfo and releaseInfo" {
+        # Arrange
+        $oldDate = (Get-Date).AddDays(-45)
+        $action = [PSCustomObject]@{
+            name = "test-action"
+            owner = "test-owner"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }
+            repoSize = 100
+            tagInfo = @(@{ tag = "v1.0.0"; sha = "abc" })
+            tagInfoCheckedAt = $oldDate
+            releaseInfo = @(@{ tag_name = "v1.0.0"; target_commitish = "main" })
+            releaseInfoCheckedAt = $oldDate
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+
+        # Act
+        $score = Get-RepoPriorityScore -action $action
+
+        # Assert
+        $score | Should -Be 30  # 15 for stale tagInfo + 15 for stale releaseInfo
+    }
 }
 
 Describe "Get-PrioritizedReposToProcess" {
     It "Should return repos with highest scores first" {
         # Arrange
         $repos = @(
-            [PSCustomObject]@{ name = "complete-repo"; owner = "test"; mirrorFound = $true; actionType = [PSCustomObject]@{ actionType = "Node" }; repoInfo = [PSCustomObject]@{ updated_at = Get-Date }; repoSize = 100; dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date } }
+            [PSCustomObject]@{ name = "complete-repo"; owner = "test"; mirrorFound = $true; actionType = [PSCustomObject]@{ actionType = "Node" }; repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }; repoSize = 100; dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date } }
             [PSCustomObject]@{ name = "missing-owner" }
             [PSCustomObject]@{ name = "missing-actionType"; owner = "test"; mirrorFound = $true }
         )
@@ -248,8 +424,12 @@ Describe "Get-PrioritizedReposToProcess" {
             owner = "test"
             mirrorFound = $true
             actionType = [PSCustomObject]@{ actionType = "Node" }
-            repoInfo = [PSCustomObject]@{ updated_at = Get-Date }
+            repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }
             repoSize = 100
+            tagInfo = @(@{ tag = "v1.0.0"; sha = "abc" })
+            tagInfoCheckedAt = Get-Date
+            releaseInfo = @(@{ tag_name = "v1.0.0"; target_commitish = "main" })
+            releaseInfoCheckedAt = Get-Date
             dependents = [PSCustomObject]@{ 
                 dependents = 50
                 dependentsLastUpdated = Get-Date 
@@ -262,8 +442,12 @@ Describe "Get-PrioritizedReposToProcess" {
             owner = "test"
             mirrorFound = $true
             actionType = [PSCustomObject]@{ actionType = "Docker" }
-            repoInfo = [PSCustomObject]@{ updated_at = Get-Date }
+            repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }
             repoSize = 200
+            tagInfo = @(@{ tag = "v2.0.0"; sha = "def" })
+            tagInfoCheckedAt = Get-Date
+            releaseInfo = @(@{ tag_name = "v2.0.0"; target_commitish = "main" })
+            releaseInfoCheckedAt = Get-Date
             dependents = [PSCustomObject]@{ 
                 dependents = 100
                 dependentsLastUpdated = Get-Date 
@@ -278,6 +462,39 @@ Describe "Get-PrioritizedReposToProcess" {
         
         # Assert
         $prioritized.Count | Should -Be 0  # All repos have score 0, so nothing to process
+    }
+
+    It "Should prioritize stale repos over fresh repos" {
+        # Arrange
+        $oldDate = (Get-Date).AddDays(-45)
+        $freshRepo = [PSCustomObject]@{
+            name = "fresh-repo"
+            owner = "test"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = Get-Date; checkedAt = Get-Date }
+            repoSize = 100
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+        $staleRepo = [PSCustomObject]@{
+            name = "stale-repo"
+            owner = "test"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{ actionType = "Node" }
+            repoInfo = [PSCustomObject]@{ updated_at = "2022-01-01T00:00:00Z" }  # no checkedAt — legacy stale
+            repoSize = 100
+            dependents = [PSCustomObject]@{ dependents = 50; dependentsLastUpdated = Get-Date }
+            fundingInfo = [PSCustomObject]@{ lastChecked = Get-Date }
+        }
+        $repos = @($freshRepo, $staleRepo)
+
+        # Act
+        $prioritized = Get-PrioritizedReposToProcess -existingForks $repos -numberOfReposToDo 10
+
+        # Assert
+        $prioritized.Count | Should -Be 1
+        $prioritized[0].name | Should -Be "stale-repo"
     }
 }
 


### PR DESCRIPTION
## Problem

All three core data fields (\epoInfo\, \	agInfo\, \eleaseInfo\) were written once and never refreshed — a write-once bug. The dataset contained entries from 2022 that were never updated (e.g. \step-security/harden-runner\ showed v2.0.0 from 2022 instead of v2.19.3).

\undingInfo\ and \dependents\ already had proper staleness checks; this brings the other fields into line.

## Changes

### \.github/workflows/repoInfo.ps1\
- **\epoInfo\**: Added \checkedAt\ timestamp on every write. Refresh guard now also triggers when \checkedAt\ is absent (legacy data) or older than 30 days.
- **\	agInfo\**: Added \	agInfoCheckedAt\ on the action object. Refresh guard now triggers when absent or older than 30 days.
- **\eleaseInfo\**: Added \eleaseInfoCheckedAt\ on the action object. Refresh guard now triggers when absent or older than 30 days.
- **\Get-RepoPriorityScore\**: Added score boosts for stale data — +45 for stale \epoInfo\ (just below +50 for missing), +15 each for stale \	agInfo\ and \eleaseInfo\. This ensures stale repos float near the top of the processing queue.

### \	ests/repoInfo-prioritization.Tests.ps1\
- Synced the duplicate \Get-RepoPriorityScore\ copy in \BeforeAll\
- Updated existing tests to include \checkedAt\ in fresh-data fixtures
- Added 5 new tests: legacy data (no \checkedAt\), stale data (>30 days), fresh data (no boost), combined stale scores, and prioritization ordering

## Effect after merge

- All ~10,551 existing entries lack \checkedAt\ → all treated as stale → +45 score boost
- At 100 repos/run, full backfill takes ~106 runs ≈ **~4.4 days**
- High-traffic actions like \step-security/harden-runner\ will be refreshed in the first few runs