### PR TITLE
fix: stop scan-organizations workflow from failing on every run

### DIFF
--- a/.github/workflows/scan-organizations.yml
+++ b/.github/workflows/scan-organizations.yml
@@ -103,9 +103,10 @@ jobs:
           "token=$($tokenResult.Token)" >> $env:GITHUB_OUTPUT
 
       # Monitor GitHub API usage during this job - version 1.2.0
+      # Note: this action has a pre: step that runs before ALL workflow steps,
+      # so we cannot pass the app token here (it's not available yet).
+      # The action defaults to github.token which is sufficient for rate-limit monitoring.
       - uses: rajbos-actions/github-api-usage-monitor@c4fab8d4f1b8cc81801ef3322a4c30ee124f7eb2
-        with:
-          token: ${{ steps.get_workflow_token.outputs.token }}
 
       - name: Load available actions for ${{ matrix.org }}
         id: load-actions


### PR DESCRIPTION
## Problem

The `scan-organizations.yml` workflow has been failing on every run (scheduled and push-triggered) for 30+ days with:

> No token provided. Set the token input or GITHUB_TOKEN environment variable.

The error comes from the `rajbos-actions/github-api-usage-monitor` action and kills the job before `Get App Token` or any other step runs.

## Root cause

The `github-api-usage-monitor` action defines a `pre:` step in its `action.yml`. GitHub Actions runs `pre:` steps for all actions in a job **before any workflow steps execute**. When the pre-step evaluated:

```yaml
token: ${{ steps.get_workflow_token.outputs.token }}
```

...`Get App Token` hadn't run yet, so the expression resolved to an empty string. Passing an explicit empty string overrides the action's built-in `default: ${{ github.token }}`, so the action threw the "No token provided" error and the entire job failed immediately.

## Fix

Remove the `token:` input from the monitor step entirely, letting it fall back to its default of `${{ github.token }}`. The monitor only needs to call `/rate_limit`, for which `github.token` is sufficient.

```yaml
# Before (broken):
- uses: rajbos-actions/github-api-usage-monitor@c4fab8d...
  with:
    token: ${{ steps.get_workflow_token.outputs.token }}  # empty at pre-step time

# After (fixed):
- uses: rajbos-actions/github-api-usage-monitor@c4fab8d...
  # uses default github.token -- sufficient for rate-limit monitoring
```