### PR TITLE
fix: refresh stale repoInfo/tagInfo/releaseInfo in analyze workflow

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -137,8 +137,22 @@ jobs:
               exit 1
           }
 
-          # Limit existing forks for repo info
-          $forksForRepoInfo = $existingForks | Where-Object { $_.forkFound -eq $true } | Select-Object -First $numberOfReposRepoInfo
+          # Limit existing forks for repo info - prioritize repos with oldest (or missing) repoInfo.updated_at so stale data gets refreshed first
+          $forksForRepoInfo = $existingForks | 
+            Where-Object { $_.forkFound -eq $true } |
+            Sort-Object -Property @{
+              Expression = {
+                try {
+                  if ($_.repoInfo -and $_.repoInfo.updated_at) {
+                    [DateTime]::Parse($_.repoInfo.updated_at).Ticks
+                  } else {
+                    0L  # No repoInfo → process first
+                  }
+                } catch { 0L }
+              };
+              Ascending = $true
+            } |
+            Select-Object -First $numberOfReposRepoInfo
           
             # Split the work for repo info
             $chunksRepoInfoRaw = Split-ForksIntoChunks -existingForks $forksForRepoInfo -numberOfChunks $numberOfChunks


### PR DESCRIPTION
## Problem

The alternative marketplace website was showing very old data for step-security/harden-runner (latest release v2.0.0 from Nov 2022, instead of v2.19.4 from May 2026).

## Root Cause

Two bugs working together:

1. repoInfo.ps1 only populated repoInfo, tagInfo, and releaseInfo when fields were *missing*. Once set (even with 2022 data), they were never refreshed. The condition was: if (!hasField || updated_at == null) — so a repo with updated_at = 2022-11-21 never got re-fetched.

2. analyze.yml selected the first 150 repos by forkFound with no staleness sorting, so repos with the oldest data were not prioritized.

The api-upsert workflow correctly detected no change (both status.json and the API had the same frozen 2022-11-21 timestamp) and skipped the upload. So the stale data was never pushed to the API.

## Fix

- repoInfo.ps1: Added a 30-day staleness check — if repoInfo.updated_at in status.json is older than 30 days, re-fetch from GitHub API to get current metadata
- repoInfo.ps1: Changed tagInfo and releaseInfo to always refresh when a repo is processed (they should always reflect current tags/releases)
- analyze.yml: Sort repos by repoInfo.updated_at ascending before selecting the 150 to process, so repos with oldest/missing data are prioritized

## Impact

After the next analyze workflow run, harden-runner (and ~2,820 other stale actions) will have their data refreshed in status.json. The next api-upsert run will detect the timestamp change and push the current data to the API, updating the website.
