### PR TITLE
fix: use Add-Member for lastFetched to handle missing property on PSCustomObject

### DIFF
--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -1620,7 +1620,7 @@ function GetMoreInfo {
                             $action.repoInfo.disabled = $repo_disabled
                             $action.repoInfo.updated_at = $repo_updated_at
                             $action.repoInfo.latest_release_published_at = $latest_release_published_at
-                            $action.repoInfo.lastFetched = (Get-Date -Format 'o')
+                            $action.repoInfo | Add-Member -Name lastFetched -Value (Get-Date -Format 'o') -MemberType NoteProperty -Force
                             $memberUpdate++ | Out-Null
                         }
                     }


### PR DESCRIPTION
## Problem

Run [#26325112059](https://github.com/rajbos/actions-marketplace-checks/actions/runs/26325112059) had 552 errors like:

> Exception setting "lastFetched": "The property 'lastFetched' cannot be found on this object. Verify that the property exists and can be set."

## Root Cause

In the \lse\ branch of \GetMoreInfo\ (updating an existing \epoInfo\ object), the code tried to directly assign:
\\\powershell
\.repoInfo.lastFetched = (Get-Date -Format 'o')
\\\

When \epoInfo\ was deserialized from JSON and did not already have a \lastFetched\ field, PowerShell throws an error because you cannot set a new property on a \PSCustomObject\ via dot notation — you must use \Add-Member\.

## Fix

Use \Add-Member -Force\ (same pattern already used for \	agInfoCheckedAt\ and \eleaseInfoCheckedAt\):
\\\powershell
\.repoInfo | Add-Member -Name lastFetched -Value (Get-Date -Format 'o') -MemberType NoteProperty -Force
\\\
\-Force\ adds the property if missing, or updates it if already present.