### PR TITLE
docs: add DB state overview shortcuts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ Tests for the cleanup functionality are located in `tests/cleanup.Tests.ps1` and
 ```powershell
 Invoke-Pester -Path ./tests/cleanup.Tests.ps1
 ```
+## DB State Overviews
+
+These two daily workflows generate a step summary you can view directly to see the current state of the database:
+
+| Workflow | What it shows | Latest runs |
+|----------|--------------|-------------|
+| **Environment State Documentation** | Coverage %, freshness, delta marketplace vs tracked, mirror & sync health | [📊 View runs](https://github.com/rajbos/actions-marketplace-checks/actions/workflows/environment-state.yml) |
+| **Generate Report** | Action type breakdown, vulnerability counts, Node/Docker versions | [📊 View runs](https://github.com/rajbos/actions-marketplace-checks/actions/workflows/report.yml) |
+
+> Click a "View runs" link → open the most recent run → scroll to the **Summary** tab to see the latest stats.
+
 ## Workflows
 
 This repository includes several automated workflows:


### PR DESCRIPTION
## Summary

Adds a **DB State Overviews** section to the README above the Workflows list, with direct links to the GitHub Actions runs pages for the two daily workflows that generate step summaries.

| Workflow | What it shows |
|---|---|
| Environment State Documentation | Coverage %, freshness, delta marketplace vs tracked, mirror & sync health |
| Generate Report | Action type breakdown, vulnerability counts, Node/Docker versions |

This makes it easy to navigate directly to the latest run summary instead of having to dig through the Actions tab.

## How to use
Click a 📊 **View runs** link → open the most recent run → scroll to the **Summary** tab.