### PR TITLE
fix: correct mermaid flowchart node syntax in report.ps1

### DIFF
--- a/.github/workflows/report.ps1
+++ b/.github/workflows/report.ps1
@@ -480,13 +480,13 @@ function ReportInsightsInMarkdown {
             # Use $localDockerFile as denominator for percentages (as per requirement: "update the percentages for D and E to use the number from B")
             $withCodePercentage = [math]::Round($localDockerfileWithCustomCode/$localDockerFile * 100 , 1)
             $withoutCodePercentage = [math]::Round($localDockerfileWithoutCustomCode/$localDockerFile * 100 , 1)
-            LogMessage "  B-->D[$DisplayIntWithDots($localDockerfileWithCustomCode) With custom code - $withCodePercentage%]"
-            LogMessage "  B-->E[$DisplayIntWithDots($localDockerfileWithoutCustomCode) Base image only - $withoutCodePercentage%]"
+            LogMessage "  B-->D[$(DisplayIntWithDots($localDockerfileWithCustomCode)) With custom code - $withCodePercentage%]"
+            LogMessage "  B-->E[$(DisplayIntWithDots($localDockerfileWithoutCustomCode)) Base image only - $withoutCodePercentage%]"
             
             # Add unknown category if there are actions without custom code information
             if ($localDockerfileUnknown -gt 0) {
                 $unknownPercentage = [math]::Round($localDockerfileUnknown/$localDockerFile * 100 , 1)
-                LogMessage "  B-->F[$DisplayIntWithDots($localDockerfileUnknown) Unknown - $unknownPercentage%]"
+                LogMessage "  B-->F[$(DisplayIntWithDots($localDockerfileUnknown)) Unknown - $unknownPercentage%]"
             }
         }
     } else {
@@ -503,18 +503,18 @@ function ReportInsightsInMarkdown {
     $totalActionsWithDefinition = $global:actionYmlFile + $global:actionYamlFile + $global:actionDockerFile + $global:actiondDockerFile
     if ($totalActionsWithDefinition -gt 0) {
         $ymlPercentage = [math]::Round($global:actionYmlFile/$totalActionsWithDefinition * 100 , 1)
-        LogMessage "  A[$DisplayIntWithDots($totalActionsWithDefinition) actions]-->B[$DisplayIntWithDots($global:actionYmlFile) action.yml - $ymlPercentage%]"
+        LogMessage "  A[$(DisplayIntWithDots($totalActionsWithDefinition)) actions]-->B[$(DisplayIntWithDots($global:actionYmlFile)) action.yml - $ymlPercentage%]"
         $yamlPercentage = [math]::Round($global:actionYamlFile/$totalActionsWithDefinition * 100 , 1)
-        LogMessage "  A-->C[$DisplayIntWithDots($global:actionYamlFile) action.yaml - $yamlPercentage%]"
+        LogMessage "  A-->C[$(DisplayIntWithDots($global:actionYamlFile)) action.yaml - $yamlPercentage%]"
         $DockerPercentage = [math]::Round($global:actionDockerFile/$totalActionsWithDefinition * 100 , 1)
-        LogMessage "  A-->D[$DisplayIntWithDots($global:actionDockerFile) Dockerfile - $DockerPercentage%]"
+        LogMessage "  A-->D[$(DisplayIntWithDots($global:actionDockerFile)) Dockerfile - $DockerPercentage%]"
         $dDockerPercentage = [math]::Round($global:actiondDockerFile/$totalActionsWithDefinition * 100 , 1)
-        LogMessage "  A-->E[$DisplayIntWithDots($global:actiondDockerFile) dockerfile - $dDockerPercentage%]"
+        LogMessage "  A-->E[$(DisplayIntWithDots($global:actiondDockerFile)) dockerfile - $dDockerPercentage%]"
     } else {
-        LogMessage "  A[$DisplayIntWithDots($totalActionsWithDefinition) actions]-->B[$DisplayIntWithDots($global:actionYmlFile) action.yml]"
-        LogMessage "  A-->C[$DisplayIntWithDots($global:actionYamlFile) action.yaml]"
-        LogMessage "  A-->D[$DisplayIntWithDots($global:actionDockerFile) Dockerfile]"
-        LogMessage "  A-->E[$DisplayIntWithDots($global:actiondDockerFile) dockerfile]"
+        LogMessage "  A[$(DisplayIntWithDots($totalActionsWithDefinition)) actions]-->B[$(DisplayIntWithDots($global:actionYmlFile)) action.yml]"
+        LogMessage "  A-->C[$(DisplayIntWithDots($global:actionYamlFile)) action.yaml]"
+        LogMessage "  A-->D[$(DisplayIntWithDots($global:actionDockerFile)) Dockerfile]"
+        LogMessage "  A-->E[$(DisplayIntWithDots($global:actiondDockerFile)) dockerfile]"
     }
     LogMessage "``````"
     LogMessage ""


### PR DESCRIPTION
## Problem

In the mermaid flowchart diagrams generated by \eport.ps1\, several node labels used \\(\)\ instead of \\\ for string interpolation.

Without the \\\ subexpression wrapper, PowerShell treats \DisplayIntWithDots\ as a null variable and outputs the numeric argument in bare parentheses, e.g. \(6064)\. In Mermaid flowchart syntax, \[(...)]\ creates a **cylindrical (database) shape** instead of a regular rectangular box \[...]\, causing two diagrams to render incorrectly.

Observed in run [#26357856837](https://github.com/rajbos/actions-marketplace-checks/actions/runs/26357856837):
\\\
B-->D[(6064) With custom code - 89.9%]   ← cylindrical shape (bug)
A[(29186) actions]-->B[(28042) action.yml - 96.1%]   ← cylindrical shape (bug)
\\\

## Fix

Replace all occurrences of \\(...)\ with \\\ in the affected mermaid diagram sections:
- Docker-based actions composition (With custom code / Base image only / Unknown nodes)
- Action definition setup (action.yml / action.yaml / Dockerfile / dockerfile nodes)

## Testing

All 6 mermaid diagram Pester tests pass.