### PR TITLE
docs: document DEVOPS_ACTIONS_PACKAGE_DOWNLOAD secret and npm package dependency

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -381,6 +381,49 @@ Watch for these patterns in logs:
    ./.github/workflows/get-github-app-token.ps1
    ```
 
+### Pattern: "npm error E403" / "Cannot find module '@devops-actions/actions-marketplace-client'"
+**Symptoms:**
+- Log shows: `npm error 403 Forbidden - GET https://npm.pkg.github.com/@devops-actions/actions-marketplace-client`
+- Error: `Permission permission_denied: The token provided does not match expected scopes.`
+- Downstream: `Error: Cannot find module '@devops-actions/actions-marketplace-client'` in Node.js upload scripts
+- Affected workflows: `api-upsert.yml`, `analyze.yml`, `repoInfo.yml`, `update-mirrors.yml`
+
+**Root Cause:**
+The `DEVOPS_ACTIONS_PACKAGE_DOWNLOAD` secret — a GitHub PAT used to install the private `@devops-actions/actions-marketplace-client` npm package from GitHub Packages — has expired, been revoked, or lost its `read:packages` scope for the `devops-actions` org.
+
+**Where the package lives:**
+- **Source repo**: `devops-actions/alternative-github-actions-marketplace`
+- **Package location**: `src/backend/package.json` — the `@devops-actions/actions-marketplace-client` package
+- **Published to**: `https://npm.pkg.github.com` (GitHub Packages)
+- **Publish workflow**: `.github/workflows/publish-npm.yml` in the source repo
+  - Triggered by: GitHub Release (tag `vX.Y.Z`) or manual `workflow_dispatch`
+  - Uses `secrets.GITHUB_TOKEN` with `packages: write` permission to publish
+
+**Quick Check:**
+```bash
+# Test if the token has valid package access
+echo $NODE_AUTH_TOKEN | gh auth login --with-token
+# Then test:
+npm view @devops-actions/actions-marketplace-client --registry=https://npm.pkg.github.com
+```
+
+**Fix — Regenerate the `DEVOPS_ACTIONS_PACKAGE_DOWNLOAD` secret:**
+1. Go to https://github.com/settings/tokens and create a new **classic PAT** (fine-grained PATs do not support GitHub Packages — this is a GitHub limitation)
+2. Required scope: `read:packages`
+3. Save the token value
+4. Go to: `rajbos/actions-marketplace-checks` → Settings → Secrets and variables → Actions
+5. Update the `DEVOPS_ACTIONS_PACKAGE_DOWNLOAD` secret with the new token value
+
+**Consumer npmrc config (for reference):**
+The workflows use `actions/setup-node@v6` with `registry-url: https://npm.pkg.github.com` and `scope: @devops-actions`, which creates an `.npmrc` equivalent to:
+```
+@devops-actions:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+Where `NODE_AUTH_TOKEN` is overridden at install-time with `${{ secrets.DEVOPS_ACTIONS_PACKAGE_DOWNLOAD }}`.
+
+---
+
 ### If Specific Workflow Consistently Fails
 
 1. **Check Workflow File Syntax**:

--- a/agent.md
+++ b/agent.md
@@ -178,6 +178,7 @@ This workflow runs daily (and on every PR/push) to validate blob storage access.
 | Secret Name | Description |
 |-------------|-------------|
 | `BLOB_SAS_TOKEN` | Full SAS URL for blob storage (read/write access). Format: `https://{storage}.blob.core.windows.net/{container}/{base-path}?{sas-params}` |
+| `DEVOPS_ACTIONS_PACKAGE_DOWNLOAD` | GitHub **classic** PAT with `read:packages` scope for the `devops-actions` org. Used to install `@devops-actions/actions-marketplace-client` from GitHub Packages during workflow runs. Fine-grained PATs do not support GitHub Packages (GitHub limitation). If this expires, all API-upload workflows will fail with npm 403 errors. See TROUBLESHOOTING.md for regeneration steps. |
 
 Note: do not introduce new secrets without asking for approval first. We use the secrets that are available in the existing workflows.
 


### PR DESCRIPTION
Documents the \@devops-actions/actions-marketplace-client\ npm package dependency and how to regenerate the \DEVOPS_ACTIONS_PACKAGE_DOWNLOAD\ secret when it expires.

## Changes

- **TROUBLESHOOTING.md**: Added new failure pattern section for \
pm error E403 / Cannot find module '@devops-actions/actions-marketplace-client'\ with root cause analysis, package location details, and step-by-step fix instructions
- **agent.md**: Added \DEVOPS_ACTIONS_PACKAGE_DOWNLOAD\ to the required secrets table with description

## Background

The \DEVOPS_ACTIONS_PACKAGE_DOWNLOAD\ secret (a classic PAT with \ead:packages\ scope) recently expired, causing all API-upload workflows to fail with npm 403 errors. Fine-grained PATs do not support GitHub Packages — only classic PATs work.