### PR TITLE
Refresh action node version by tying re-parse to repo change date

### DIFF
--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -810,28 +810,36 @@ function CheckForInfoUpdateNeeded {
         return $true
     }
 
-    # Re-check the action definition periodically so that changes to the
-    # upstream action (for example a node version bump like node16 -> node24)
-    # get picked up. Without this, once actionType/nodeVersion are set they are
-    # never refreshed and the stored data becomes stale.
-    $recheckAfterDays = 30
-    $hasActionTypeUpdated = $null -ne $action.actionType.actionTypeLastUpdated
-    if (!$hasActionTypeUpdated) {
-        # Legacy record without a timestamp: refresh once to capture the
-        # current state and start tracking when it was last checked.
+    # Tie re-parsing of the action definition (action.yml/action.yaml) to the
+    # repository's change date. When the repo has changed since we last parsed
+    # it, the stored properties (actionType, fileFound, actionDockerType,
+    # nodeVersion) may be stale - for example a node version bump like
+    # node16 -> node24 - so we re-parse and refresh everything we can read.
+    $storedRepoUpdatedAt = $action.actionType.repoUpdatedAt
+    if ($null -eq $storedRepoUpdatedAt) {
+        # Legacy record parsed before we tracked the repo change date: refresh
+        # once to capture the current state and establish the baseline.
         return $true
     }
-    else {
+
+    $currentRepoUpdatedAt = $action.mirrorLastUpdated
+    if ($null -ne $currentRepoUpdatedAt) {
+        $repoChanged = $false
         try {
-            $actionTypeUpdated = [datetime]$action.actionType.actionTypeLastUpdated
-            $daysSinceActionTypeUpdate = ((Get-Date) - $actionTypeUpdated).TotalDays
-            if ($daysSinceActionTypeUpdate -gt $recheckAfterDays) {
-                return $true
+            $storedDate = [datetime]$storedRepoUpdatedAt
+            $currentDate = [datetime]$currentRepoUpdatedAt
+            if ($currentDate -gt $storedDate) {
+                $repoChanged = $true
             }
         }
         catch {
-            # If we cannot parse the stored timestamp, err on the side of
-            # refreshing so we do not keep stale data indefinitely.
+            # Fall back to a string comparison if either value is not a
+            # parseable date; refresh when they differ.
+            if ("$currentRepoUpdatedAt" -ne "$storedRepoUpdatedAt") {
+                $repoChanged = $true
+            }
+        }
+        if ($repoChanged) {
             return $true
         }
     }
@@ -1021,7 +1029,15 @@ function GetInfo {
             }
         }
         else {
-            $action.mirrorLastUpdated = $response.updated_at
+            if ($null -eq $response) {
+                $response = MakeRepoInfoCall -action $action -forkOrg $forkOrg -accessToken $accessToken -startTime $startTime
+            }
+            # only refresh the change date when we actually retrieved one; do
+            # not overwrite a known value with null when the call failed. This
+            # keeps the repo change date reliable for action re-parsing.
+            if ($response -and $response.updated_at) {
+                $action.mirrorLastUpdated = $response.updated_at
+            }
         }
 
         # store repo size (only set when we have a valid value)
@@ -1117,6 +1133,7 @@ function GetInfo {
                     fileFound = $fileFoundResult
                     actionDockerType = $actionDockerTypeResult
                     nodeVersion = $nodeVersion
+                    repoUpdatedAt = $action.mirrorLastUpdated
                     actionTypeLastUpdated = Get-Date
                 }
 
@@ -1134,8 +1151,9 @@ function GetInfo {
                 else {
                     $action.actionType.nodeVersion = $nodeVersion
                 }
-                # record when we last determined the actionType so stale data
-                # (for example an outdated node version) gets refreshed later
+                # Record the repo change date we parsed against and when we
+                # parsed, so re-parsing is tied to the repo actually changing.
+                $action.actionType | Add-Member -Name repoUpdatedAt -Value $action.mirrorLastUpdated -MemberType NoteProperty -Force
                 $action.actionType | Add-Member -Name actionTypeLastUpdated -Value (Get-Date) -MemberType NoteProperty -Force
                 $i++ | Out-Null
                 $repoHadUpdates = $true

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -810,6 +810,32 @@ function CheckForInfoUpdateNeeded {
         return $true
     }
 
+    # Re-check the action definition periodically so that changes to the
+    # upstream action (for example a node version bump like node16 -> node24)
+    # get picked up. Without this, once actionType/nodeVersion are set they are
+    # never refreshed and the stored data becomes stale.
+    $recheckAfterDays = 30
+    $hasActionTypeUpdated = $null -ne $action.actionType.actionTypeLastUpdated
+    if (!$hasActionTypeUpdated) {
+        # Legacy record without a timestamp: refresh once to capture the
+        # current state and start tracking when it was last checked.
+        return $true
+    }
+    else {
+        try {
+            $actionTypeUpdated = [datetime]$action.actionType.actionTypeLastUpdated
+            $daysSinceActionTypeUpdate = ((Get-Date) - $actionTypeUpdated).TotalDays
+            if ($daysSinceActionTypeUpdate -gt $recheckAfterDays) {
+                return $true
+            }
+        }
+        catch {
+            # If we cannot parse the stored timestamp, err on the side of
+            # refreshing so we do not keep stale data indefinitely.
+            return $true
+        }
+    }
+
     # Check if we are nearing the 50-minute mark
     $timeSpan = (Get-Date) - $startTime
     if ($timeSpan.TotalMinutes -gt 50) {
@@ -1091,6 +1117,7 @@ function GetInfo {
                     fileFound = $fileFoundResult
                     actionDockerType = $actionDockerTypeResult
                     nodeVersion = $nodeVersion
+                    actionTypeLastUpdated = Get-Date
                 }
 
                 $action | Add-Member -Name actionType -Value $actionType -MemberType NoteProperty
@@ -1107,6 +1134,9 @@ function GetInfo {
                 else {
                     $action.actionType.nodeVersion = $nodeVersion
                 }
+                # record when we last determined the actionType so stale data
+                # (for example an outdated node version) gets refreshed later
+                $action.actionType | Add-Member -Name actionTypeLastUpdated -Value (Get-Date) -MemberType NoteProperty -Force
                 $i++ | Out-Null
                 $repoHadUpdates = $true
             }

--- a/tests/actionTypeRecheck.Tests.ps1
+++ b/tests/actionTypeRecheck.Tests.ps1
@@ -28,20 +28,27 @@ BeforeAll {
             return $true
         }
 
-        $recheckAfterDays = 30
-        $hasActionTypeUpdated = $null -ne $action.actionType.actionTypeLastUpdated
-        if (!$hasActionTypeUpdated) {
+        $storedRepoUpdatedAt = $action.actionType.repoUpdatedAt
+        if ($null -eq $storedRepoUpdatedAt) {
             return $true
         }
-        else {
+
+        $currentRepoUpdatedAt = $action.mirrorLastUpdated
+        if ($null -ne $currentRepoUpdatedAt) {
+            $repoChanged = $false
             try {
-                $actionTypeUpdated = [datetime]$action.actionType.actionTypeLastUpdated
-                $daysSinceActionTypeUpdate = ((Get-Date) - $actionTypeUpdated).TotalDays
-                if ($daysSinceActionTypeUpdate -gt $recheckAfterDays) {
-                    return $true
+                $storedDate = [datetime]$storedRepoUpdatedAt
+                $currentDate = [datetime]$currentRepoUpdatedAt
+                if ($currentDate -gt $storedDate) {
+                    $repoChanged = $true
                 }
             }
             catch {
+                if ("$currentRepoUpdatedAt" -ne "$storedRepoUpdatedAt") {
+                    $repoChanged = $true
+                }
+            }
+            if ($repoChanged) {
                 return $true
             }
         }
@@ -57,11 +64,12 @@ BeforeAll {
     }
 }
 
-Describe "CheckForInfoUpdateNeeded node version staleness" {
-    It "requests an update for a legacy Node action without a lastUpdated timestamp" {
+Describe "CheckForInfoUpdateNeeded ties action re-parsing to repo change date" {
+    It "requests an update for a legacy record without a stored repoUpdatedAt" {
         $action = [PSCustomObject]@{
-            name       = "actions/checkout"
-            mirrorFound = $true
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = "2024-01-10T10:00:00Z"
             actionType = [PSCustomObject]@{
                 actionType  = "Node"
                 nodeVersion = "16"
@@ -71,42 +79,60 @@ Describe "CheckForInfoUpdateNeeded node version staleness" {
         $result | Should -Be $true
     }
 
-    It "requests an update when the actionType is older than the recheck window" {
+    It "requests an update when the repo changed since it was last parsed" {
         $action = [PSCustomObject]@{
-            name       = "actions/checkout"
-            mirrorFound = $true
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = "2024-06-01T12:00:00Z"
             actionType = [PSCustomObject]@{
-                actionType            = "Node"
-                nodeVersion           = "16"
-                actionTypeLastUpdated = (Get-Date).AddDays(-31)
+                actionType    = "Node"
+                nodeVersion   = "16"
+                repoUpdatedAt = "2024-01-10T10:00:00Z"
             }
         }
         $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
         $result | Should -Be $true
     }
 
-    It "does not request an update when the actionType was checked recently" {
+    It "does not request an update when the repo is unchanged since last parse" {
         $action = [PSCustomObject]@{
-            name       = "actions/checkout"
-            mirrorFound = $true
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = "2024-01-10T10:00:00Z"
             actionType = [PSCustomObject]@{
-                actionType            = "Node"
-                nodeVersion           = "24"
-                actionTypeLastUpdated = (Get-Date).AddDays(-1)
+                actionType    = "Node"
+                nodeVersion   = "24"
+                repoUpdatedAt = "2024-01-10T10:00:00Z"
             }
         }
         $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
         $result | Should -Be $false
     }
 
-    It "requests an update when the stored timestamp cannot be parsed" {
+    It "does not request an update when the current repo date is missing" {
         $action = [PSCustomObject]@{
-            name       = "actions/checkout"
-            mirrorFound = $true
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = $null
             actionType = [PSCustomObject]@{
-                actionType            = "Node"
-                nodeVersion           = "16"
-                actionTypeLastUpdated = "not-a-date"
+                actionType    = "Node"
+                nodeVersion   = "24"
+                repoUpdatedAt = "2024-01-10T10:00:00Z"
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result | Should -Be $false
+    }
+
+    It "requests an update when dates are unparseable but differ" {
+        $action = [PSCustomObject]@{
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = "changed-marker-b"
+            actionType = [PSCustomObject]@{
+                actionType    = "Node"
+                nodeVersion   = "16"
+                repoUpdatedAt = "changed-marker-a"
             }
         }
         $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)

--- a/tests/actionTypeRecheck.Tests.ps1
+++ b/tests/actionTypeRecheck.Tests.ps1
@@ -1,0 +1,115 @@
+BeforeAll {
+    # Define CheckForInfoUpdateNeeded inline (mirrors repoInfo.ps1) to avoid
+    # loading repoInfo.ps1's script-level code that requires GitHub tokens.
+    function CheckForInfoUpdateNeeded {
+        Param (
+            $action,
+            $hasActionTypeField,
+            $hasNodeVersionField,
+            $startTime
+        )
+
+        # skip actions where we cannot find the fork anymore
+        if (!$action.mirrorFound) {
+            return $false
+        }
+        # check actionType field missing or not filled actionType in it
+        if (!$hasActionTypeField -or ($null -eq $action.actionType.actionType)) {
+            return $true
+        }
+
+        # check nodeVersion field missing or not filled actionType in it
+        if (("No file found" -eq $action.actionType.actionType) -or ("No repo found" -eq $action.actionType.actionType)) {
+            return $true
+        }
+
+        # check nodeVersion field missing for Node actionType
+        if (("Node" -eq $action.actionType.actionType) -and !$hasNodeVersionField) {
+            return $true
+        }
+
+        $recheckAfterDays = 30
+        $hasActionTypeUpdated = $null -ne $action.actionType.actionTypeLastUpdated
+        if (!$hasActionTypeUpdated) {
+            return $true
+        }
+        else {
+            try {
+                $actionTypeUpdated = [datetime]$action.actionType.actionTypeLastUpdated
+                $daysSinceActionTypeUpdate = ((Get-Date) - $actionTypeUpdated).TotalDays
+                if ($daysSinceActionTypeUpdate -gt $recheckAfterDays) {
+                    return $true
+                }
+            }
+            catch {
+                return $true
+            }
+        }
+
+        # Check if we are nearing the 50-minute mark
+        $timeSpan = (Get-Date) - $startTime
+        if ($timeSpan.TotalMinutes -gt 50) {
+            Write-Host "Stopping the run, since we are nearing the 50-minute mark"
+            return
+        }
+
+        return $false
+    }
+}
+
+Describe "CheckForInfoUpdateNeeded node version staleness" {
+    It "requests an update for a legacy Node action without a lastUpdated timestamp" {
+        $action = [PSCustomObject]@{
+            name       = "actions/checkout"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{
+                actionType  = "Node"
+                nodeVersion = "16"
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result | Should -Be $true
+    }
+
+    It "requests an update when the actionType is older than the recheck window" {
+        $action = [PSCustomObject]@{
+            name       = "actions/checkout"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{
+                actionType            = "Node"
+                nodeVersion           = "16"
+                actionTypeLastUpdated = (Get-Date).AddDays(-31)
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result | Should -Be $true
+    }
+
+    It "does not request an update when the actionType was checked recently" {
+        $action = [PSCustomObject]@{
+            name       = "actions/checkout"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{
+                actionType            = "Node"
+                nodeVersion           = "24"
+                actionTypeLastUpdated = (Get-Date).AddDays(-1)
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result | Should -Be $false
+    }
+
+    It "requests an update when the stored timestamp cannot be parsed" {
+        $action = [PSCustomObject]@{
+            name       = "actions/checkout"
+            mirrorFound = $true
+            actionType = [PSCustomObject]@{
+                actionType            = "Node"
+                nodeVersion           = "16"
+                actionTypeLastUpdated = "not-a-date"
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result | Should -Be $true
+    }
+}


### PR DESCRIPTION
## Problem
Actions showed a stale node version on the alternative marketplace (e.g. `actions/checkout` displayed as node16 while its `action.yml` is node24).

`GetActionType` parses `runs.using` correctly, but `CheckForInfoUpdateNeeded` only requested a re-parse when `actionType`/`nodeVersion` were **missing**. Once set, the action definition was never parsed again, so upstream changes (like a node version bump) were never reflected.

## Fix
Tie re-parsing of the action definition (`action.yml`/`action.yaml`) to the repository's change date:

- `CheckForInfoUpdateNeeded` now re-parses when the repo has changed since it was last parsed, by comparing the stored `repoUpdatedAt` against the current `mirrorLastUpdated` (date compare, with a string-inequality fallback). Legacy records without `repoUpdatedAt` are refreshed once to establish a baseline.
- On every parse, all properties are refreshed (`actionType`, `fileFound`, `actionDockerType`, `nodeVersion`) and `repoUpdatedAt` + `actionTypeLastUpdated` are stamped.
- Guarded `mirrorLastUpdated` so a failed repo-info call no longer overwrites the known change date with `null`.

## Tests
- New `tests/actionTypeRecheck.Tests.ps1` (5 cases: legacy, repo-changed, unchanged, missing current date, unparseable-but-differ) — all pass.
- Existing 31 `validateStatusSchema` tests still pass; script parses cleanly.