### PR TITLE
perf(ci): fix pester-tests slowness — drop fetch-depth:0 in checkout

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -19,15 +19,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
+        # No fetch-depth: 0 here - this repo's history contains large JSON
+        # snapshots (status.json etc.) across many commits, which made a full
+        # clone take ~20 minutes. A shallow checkout (default depth) is all
+        # that's needed since the PS1-change check below uses the GitHub API
+        # instead of local git history.
 
       - name: Check for PS1 file changes
         id: ps1-check
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '\.ps1$'; then
+            if gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename' | grep -qE '\.ps1$'; then
               echo "changed=true" >> $GITHUB_OUTPUT
               echo "PS1 files changed, running tests"
             else


### PR DESCRIPTION
## Problem
The `pester-tests.yml` workflow was consistently taking ~20 minutes (as seen in [run 30213322748](https://github.com/rajbos/actions-marketplace-checks/actions/runs/30213322748/job/89823117716?pr=240)), which felt way too slow for running Pester tests.

## Root cause
Checked step timings on the last several completed runs — the actual `Invoke-Pester` step only takes **~24 seconds**. The bottleneck is the `actions/checkout@v7` step, which was using `fetch-depth: 0` (full history clone) and consistently took **~20.5 minutes**. This repo's git history contains large JSON snapshots (`status.json` ~29MB, `status-old.json`, backups, etc.) across thousands of commits, so a full clone is very expensive.

The full history was only being used by the "Check for PS1 file changes" step, which ran `git diff --name-only origin/${{ github.base_ref }}...HEAD` to decide whether to skip the test run on PRs that don't touch `.ps1` files.

## Fix
- Removed `fetch-depth: 0` so `actions/checkout` uses its default shallow depth.
- Replaced the local `git diff` with a call to the GitHub API (`GET /repos/{owner}/{repo}/pulls/{pr}/files`) to get the list of changed files for the PR, so no git history is needed at all for that check.

## Expected result
The workflow should now complete in well under a minute (previously ~20-21 minutes), since checkout no longer needs to clone the full repo history.