### PR TITLE
Improve Docker image handling and Trivy scan failure tracking

### DIFF
--- a/.github/workflows/environment-state.ps1
+++ b/.github/workflows/environment-state.ps1
@@ -409,6 +409,7 @@ $dockerActionsTotal = 0
 $dockerWithCompositionInfo = 0
 $dockerLocalDockerfile = 0
 $dockerRemoteImage = 0
+$dockerRemoteImageWithReference = 0
 $dockerLocalWithCustomCode = 0
 $dockerLocalWithoutCustomCode = 0
 $dockerLocalWithCustomCodeInfo = 0
@@ -438,6 +439,9 @@ foreach ($fork in $existingForks) {
             }
             elseif ($fork.actionType.actionDockerType -eq "Image") {
                 $dockerRemoteImage++
+                if ($fork.actionType.dockerImageReference) {
+                    $dockerRemoteImageWithReference++
+                }
             }
         }
     }
@@ -458,6 +462,12 @@ $percentLocalDockerfile = if ($dockerWithCompositionInfo -gt 0) {
 
 $percentRemoteImage = if ($dockerWithCompositionInfo -gt 0) {
     [math]::Round(($dockerRemoteImage / $dockerWithCompositionInfo) * 100, 2)
+} else {
+    0
+}
+
+$percentRemoteImageWithReference = if ($dockerRemoteImage -gt 0) {
+    [math]::Round(($dockerRemoteImageWithReference / $dockerRemoteImage) * 100, 2)
 } else {
     0
 }
@@ -485,6 +495,7 @@ if ($dockerWithCompositionInfo -gt 0) {
     Write-Message -message "|-----------------|------:|-----------:|" -logToSummary $true
     Write-Message -message "| 📦 Local Dockerfile | $(DisplayIntWithDots $dockerLocalDockerfile) | ${percentLocalDockerfile}% |" -logToSummary $true
     Write-Message -message "| 🌐 Remote Image | $(DisplayIntWithDots $dockerRemoteImage) | ${percentRemoteImage}% |" -logToSummary $true
+    Write-Message -message "| 🌐 Remote Image with reference | $(DisplayIntWithDots $dockerRemoteImageWithReference) | ${percentRemoteImageWithReference}% |" -logToSummary $true
     Write-Message -message "" -logToSummary $true
     
     # Show custom code analysis for local Dockerfiles

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -564,11 +564,11 @@ function GetActionType {
     )
 
     if ($null -eq $owner) {
-        return ("No owner found", "No owner found", "No owner found", $null)
+        return ("No owner found", "No owner found", "No owner found", $null, "")
     }
 
     if ($null -eq $repo) {
-        return ("No repo found", "No repo found", "No repo found", $null)
+        return ("No repo found", "No repo found", "No repo found", $null, "")
     }
 
     # Check if we are nearing the 50-minute mark
@@ -582,6 +582,7 @@ function GetActionType {
     $response = ""
     $fileFound = ""
     $actionType = ""
+    $dockerImageReference = ""
     try {
         $url = "/repos/$owner/$repo/contents/action.yml"
         $response = ApiCall -method GET -url $url -hideFailedCall $true -access_token $accessToken
@@ -602,7 +603,7 @@ function GetActionType {
                 $actionDockerType = "Dockerfile"
                 $actionType = "Docker"
 
-                return ($actionType, $fileFound, $actionDockerType)
+                return ($actionType, $fileFound, $actionDockerType, $null, $dockerImageReference)
             }
             catch {
                 try {
@@ -612,11 +613,11 @@ function GetActionType {
                     $actionDockerType = "Dockerfile"
                     $actionType = "Docker"
 
-                    return ($actionType, $fileFound, $actionDockerType)
+                    return ($actionType, $fileFound, $actionDockerType, $null, $dockerImageReference)
                 }
                 catch {
                     Write-Debug "No action.yml or action.yaml or Dockerfile or dockerfile found in repo [$owner/$repo]"
-                    return ("No file found", "No file found", "No file found")
+                    return ("No file found", "No file found", "No file found", $null, $dockerImageReference)
                 }
             }
         }
@@ -624,7 +625,7 @@ function GetActionType {
 
     if ($response.Length -eq 0 -or $response.download_url.Length -eq 0) {
         Write-Debug "No action definition found in repo [$owner/$repo]"
-        return ("No file found", "No file found", "No file found")
+        return ("No file found", "No file found", "No file found", $null, "")
     }
 
     # load the file
@@ -647,7 +648,7 @@ function GetActionType {
             }
         }
         
-        return ("Error downloading file", "No file found", "No file found")
+        return ("Error downloading file", "No file found", "No file found", $null, "")
     }
     
     Write-Debug "response: $($fileContent)"
@@ -658,7 +659,7 @@ function GetActionType {
         Write-Host "Error converting to yaml: $($_.Exception.Message)"
         Write-Host "Yaml content repo [$owner/$repo]:"
         Write-Host $fileContent
-        return "Unknown"
+        return ("Unknown", "No file found", "No file found", $null, "")
     }
 
     # find line that says "
@@ -672,11 +673,13 @@ function GetActionType {
     $actionDockerType = ""
     if ($using -eq "docker") {
         $actionType = "Docker"
-        if ($yaml.runs.image -eq "Dockerfile" -or $yaml.runs.image -eq "./Dockerfile" -or $yaml.runs.image -eq ".\Dockerfile") {
+        $image = $yaml.runs.image
+        if ($image -eq "Dockerfile" -or $image -eq "./Dockerfile" -or $image -eq ".\Dockerfile") {
             $actionDockerType = "Dockerfile"
         }
         else {
             $actionDockerType = "Image"
+            $dockerImageReference = $image
         }
     }
     else {
@@ -692,7 +695,7 @@ function GetActionType {
         }
     }
 
-    return ($actionType, $fileFound, $actionDockerType, $nodeVersion)
+    return ($actionType, $fileFound, $actionDockerType, $nodeVersion, $dockerImageReference)
 }
 
 function CheckForInfoUpdateNeeded {
@@ -1037,7 +1040,7 @@ function GetInfo {
         if ($updateNeeded) {
             ($owner, $repo) = GetOrgActionInfo($action.name)
             Write-Host "$i/$max - Checking action information for [$($owner)/$($repo)]"
-            ($actionTypeResult, $fileFoundResult, $actionDockerTypeResult, $nodeVersion) = GetActionType -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
+            ($actionTypeResult, $fileFoundResult, $actionDockerTypeResult, $nodeVersion, $dockerImageReference) = GetActionType -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
 
             If (!$hasActionTypeField) {
                 $actionType = @{
@@ -1045,6 +1048,7 @@ function GetInfo {
                     fileFound = $fileFoundResult
                     actionDockerType = $actionDockerTypeResult
                     nodeVersion = $nodeVersion
+                    dockerImageReference = $dockerImageReference
                     repoUpdatedAt = $action.mirrorLastUpdated
                     actionTypeLastUpdated = Get-Date
                 }
@@ -1063,6 +1067,7 @@ function GetInfo {
                 else {
                     $action.actionType.nodeVersion = $nodeVersion
                 }
+                $action.actionType | Add-Member -Name dockerImageReference -Value $dockerImageReference -MemberType NoteProperty -Force
                 # Record the repo change date we parsed against and when we
                 # parsed, so re-parsing is tied to the repo actually changing.
                 $action.actionType | Add-Member -Name repoUpdatedAt -Value $action.mirrorLastUpdated -MemberType NoteProperty -Force
@@ -1233,6 +1238,11 @@ function GetRepoDockerBaseImage {
         hasCustomCode = $false
     }
     
+    if ($actionType.actionDockerType -eq "Image") {
+        # Remote image actions reference an image in action.yml; there is no repo-local Dockerfile to analyze here.
+        return $result
+    }
+
     if ($actionType.actionDockerType -eq "Dockerfile") {
         $url = "/repos/$owner/$repo/contents/Dockerfile"
         $repoUrl = "https://github.com/$owner/$repo"
@@ -1719,38 +1729,61 @@ function GetMoreInfo {
                 $hasBaseImageField = Get-Member -inputobject $action.actionType -name "dockerBaseImage" -Membertype Properties
                 $hasCustomCodeField = Get-Member -inputobject $action.actionType -name "dockerfileHasCustomCode" -Membertype Properties
                 
-                # Check if we need to get or update Docker info
-                $needsDockerInfo = (!$hasBaseImageField -or ($null -eq $action.actionType.dockerBaseImage) -And $action.actionType.actionDockerType -ne "Image") -or !$hasCustomCodeField
-                
-                if ($needsDockerInfo) {
-                    Write-Host "$i/$max - Checking Docker information for [$($owner)/$($repo)]. hasBaseImageField: [$hasBaseImageField], hasCustomCodeField: [$hasCustomCodeField], actionType: [$($action.actionType.actionType)], actionDockerType: [$($action.actionType.actionDockerType)]"
-                    try {
-                        # search for the docker file in the fork organization, since the original repo might already have seen updates
-                        $dockerInfo = GetRepoDockerBaseImage -owner $owner -repo $repo -actionType $action.actionType -accessToken $accessToken
-                        
-                        if ($dockerInfo.dockerBaseImage -ne "") {
-                            if (!$hasBaseImageField) {
-                                Write-Host "Adding Docker base image information with image:[$($dockerInfo.dockerBaseImage)], hasCustomCode:[$($dockerInfo.hasCustomCode)] for [$($action.owner)/$($action.name))]"
-                                $action.actionType | Add-Member -Name dockerBaseImage -Value $dockerInfo.dockerBaseImage -MemberType NoteProperty
-                                $i++ | Out-Null
-                                $dockerBaseImageInfoAdded++ | Out-Null
-                            }
-                            else {
-                                Write-Host "Updating Docker base image information with image:[$($dockerInfo.dockerBaseImage)] for [$($owner)/$($repo))]"
-                                $action.actionType.dockerBaseImage = $dockerInfo.dockerBaseImage
-                            }
+                if ($action.actionType.actionDockerType -eq "Image") {
+                    # Remote Docker image actions do not have a repo-local Dockerfile to analyze.
+                    # Annotate the image reference and record that there is no base image/custom-code info.
+                    $imageRef = $action.actionType.dockerImageReference
+                    Write-Host "$i/$max - Docker action [$($owner)/$($repo)] uses remote image [$imageRef]; skipping Dockerfile analysis"
+
+                    if (!$hasBaseImageField) {
+                        $action.actionType | Add-Member -Name dockerBaseImage -Value $null -MemberType NoteProperty
+                        $i++ | Out-Null
+                    }
+                    else {
+                        $action.actionType.dockerBaseImage = $null
+                    }
+
+                    if (!$hasCustomCodeField) {
+                        $action.actionType | Add-Member -Name dockerfileHasCustomCode -Value $null -MemberType NoteProperty
+                    }
+                    else {
+                        $action.actionType.dockerfileHasCustomCode = $null
+                    }
+                }
+                elseif ($action.actionType.actionDockerType -eq "Dockerfile") {
+                    # Check if we need to get or update Dockerfile-based Docker info
+                    $needsDockerInfo = !$hasBaseImageField -or ($null -eq $action.actionType.dockerBaseImage) -or !$hasCustomCodeField
+                    
+                    if ($needsDockerInfo) {
+                        Write-Host "$i/$max - Checking Docker information for [$($owner)/$($repo)]. hasBaseImageField: [$hasBaseImageField], hasCustomCodeField: [$hasCustomCodeField], actionType: [$($action.actionType.actionType)], actionDockerType: [$($action.actionType.actionDockerType)]"
+                        try {
+                            # search for the docker file in the fork organization, since the original repo might already have seen updates
+                            $dockerInfo = GetRepoDockerBaseImage -owner $owner -repo $repo -actionType $action.actionType -accessToken $accessToken
                             
-                            # Add or update hasCustomCode field
-                            if (!$hasCustomCodeField) {
-                                $action.actionType | Add-Member -Name dockerfileHasCustomCode -Value $dockerInfo.hasCustomCode -MemberType NoteProperty
-                            }
-                            else {
-                                $action.actionType.dockerfileHasCustomCode = $dockerInfo.hasCustomCode
+                            if ($dockerInfo.dockerBaseImage -ne "") {
+                                if (!$hasBaseImageField) {
+                                    Write-Host "Adding Docker base image information with image:[$($dockerInfo.dockerBaseImage)], hasCustomCode:[$($dockerInfo.hasCustomCode)] for [$($action.owner)/$($action.name))]"
+                                    $action.actionType | Add-Member -Name dockerBaseImage -Value $dockerInfo.dockerBaseImage -MemberType NoteProperty
+                                    $i++ | Out-Null
+                                    $dockerBaseImageInfoAdded++ | Out-Null
+                                }
+                                else {
+                                    Write-Host "Updating Docker base image information with image:[$($dockerInfo.dockerBaseImage)] for [$($owner)/$($repo))]"
+                                    $action.actionType.dockerBaseImage = $dockerInfo.dockerBaseImage
+                                }
+                                
+                                # Add or update hasCustomCode field
+                                if (!$hasCustomCodeField) {
+                                    $action.actionType | Add-Member -Name dockerfileHasCustomCode -Value $dockerInfo.hasCustomCode -MemberType NoteProperty
+                                }
+                                else {
+                                    $action.actionType.dockerfileHasCustomCode = $dockerInfo.hasCustomCode
+                                }
                             }
                         }
-                    }
-                    catch {
-                        # continue with next one
+                        catch {
+                            # continue with next one
+                        }
                     }
                 }
 

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -851,6 +851,7 @@ function GetInfo {
         ActionFile404 = @()
         OtherErrors = @()
     }
+    $script:trivyScanFailures = @()
 
     # Initialize tracking for summary
     $script:processMetrics = @{
@@ -1329,6 +1330,13 @@ function Invoke-TrivyScan {
         $accessToken
     )
 
+    $result = @{
+        critical = 0
+        high = 0
+        lastScanned = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+        scanError = $null
+    }
+
     # Only scan Docker actions with Dockerfiles (not remote images)
     if ($actionType.actionDockerType -ne "Dockerfile") {
         Write-Debug "Skipping Trivy scan for [$owner/$repo] - not a Dockerfile-based action (type: $($actionType.actionDockerType))"
@@ -1350,7 +1358,8 @@ function Invoke-TrivyScan {
             $trivyPath = Get-Command trivy -ErrorAction SilentlyContinue
             if (-not $trivyPath) {
                 Write-Host "Failed to install Trivy for [$owner/$repo]"
-                return $null
+                $result.scanError = "Trivy installation failed"
+                return $result
             }
         }
 
@@ -1376,7 +1385,8 @@ function Invoke-TrivyScan {
 
             if (-not $dockerFile -or -not $dockerFile.download_url) {
                 Write-Host "Could not retrieve Dockerfile for [$owner/$repo]"
-                return $null
+                $result.scanError = "Dockerfile not found"
+                return $result
             }
 
             # Download Dockerfile content
@@ -1395,7 +1405,8 @@ function Invoke-TrivyScan {
                 
                 if ($LASTEXITCODE -ne 0) {
                     Write-Host "Trivy scan failed for [$owner/$repo]: $scanOutput"
-                    return $null
+                    $result.scanError = "Trivy scan failed"
+                    return $result
                 }
             }
             
@@ -1403,13 +1414,6 @@ function Invoke-TrivyScan {
             try {
                 $scanResults = $scanOutput | ConvertFrom-Json
                 
-                $result = @{
-                    critical = 0
-                    high = 0
-                    lastScanned = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
-                    scanError = $null
-                }
-
                 # Count vulnerabilities by severity
                 if ($scanResults.Results) {
                     foreach ($target in $scanResults.Results) {
@@ -1437,11 +1441,10 @@ function Invoke-TrivyScan {
                 }
                 
                 Write-Host "Trivy scan completed for [$owner/$repo]: Critical=$($result.critical), High=$($result.high)"
-                return $result
             }
             catch {
                 Write-Host "Failed to parse Trivy output for [$owner/$repo]: $($_.Exception.Message)"
-                return $null
+                $result.scanError = "Failed to parse Trivy output"
             }
         }
         finally {
@@ -1453,10 +1456,10 @@ function Invoke-TrivyScan {
     }
     catch {
         Write-Host "Error during Trivy scan for [$owner/$repo]: $($_.Exception.Message)"
-        return $null
+        $result.scanError = $_.Exception.Message
     }
 
-    return $null
+    return $result
 }
 
 function GetMoreInfo {
@@ -1812,7 +1815,7 @@ function GetMoreInfo {
                     try {
                         $scanResult = Invoke-TrivyScan -owner $owner -repo $repo -actionType $action.actionType -accessToken $accessToken
                         
-                        if ($null -ne $scanResult) {
+                        if ($null -ne $scanResult -and $null -eq $scanResult.scanError) {
                             if (!$hasContainerScanField) {
                                 Write-Host "Adding container scan information with critical:[$($scanResult.critical)], high:[$($scanResult.high)] for [$($action.owner)/$($action.name))]"
                                 $action.actionType | Add-Member -Name containerScan -Value $scanResult -MemberType NoteProperty
@@ -1822,12 +1825,26 @@ function GetMoreInfo {
                                 $action.actionType.containerScan = $scanResult
                             }
                         }
-                        else {
-                            Write-Host "Trivy scan did not complete for [$($owner)/$($repo)]; result will not be stored and will be retried"
+                        elseif ($null -ne $scanResult -and $null -ne $scanResult.scanError) {
+                            Write-Host "Trivy scan failed for [$($owner)/$($repo)]: $($scanResult.scanError); result will not be stored and will be retried"
+                            $dockerSource = if ($action.actionType.fileFound) { $action.actionType.fileFound } else { $action.actionType.actionDockerType }
+                            $script:trivyScanFailures += @{
+                                ownerRepo = "$owner/$repo"
+                                dockerSource = $dockerSource
+                                error = $scanResult.scanError
+                                timestamp = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+                            }
                         }
                     }
                     catch {
                         Write-Host "Error running Trivy scan for [$owner/$repo]: $($_.Exception.Message)"
+                        $dockerSource = if ($action.actionType.fileFound) { $action.actionType.fileFound } else { $action.actionType.actionDockerType }
+                        $script:trivyScanFailures += @{
+                            ownerRepo = "$owner/$repo"
+                            dockerSource = $dockerSource
+                            error = $_.Exception.Message
+                            timestamp = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+                        }
                         # continue with next one
                     }
                 }
@@ -1951,6 +1968,28 @@ function GetMoreInfo {
         $stepSummaryOutput += "`n</details>`n"
         
         Write-Message -message $stepSummaryOutput -logToSummary $true
+    }
+
+    # Write Trivy scan failures to a file for artifact upload
+    $trivyFailuresFile = "trivy-scan-failures.json"
+    if ($null -ne $script:trivyScanFailures -and $script:trivyScanFailures.Count -gt 0) {
+        try {
+            $script:trivyScanFailures | ConvertTo-Json -Depth 5 | Out-File -FilePath $trivyFailuresFile -Encoding UTF8
+            Write-Host "Wrote [$($script:trivyScanFailures.Count)] Trivy scan failures to [$trivyFailuresFile]"
+        }
+        catch {
+            Write-Host "Error writing Trivy scan failures to [$trivyFailuresFile]: $($_.Exception.Message)"
+        }
+    }
+    else {
+        # Ensure an empty file exists so the artifact upload step has a predictable file
+        try {
+            "[]" | Out-File -FilePath $trivyFailuresFile -Encoding UTF8
+            Write-Host "No Trivy scan failures; wrote empty array to [$trivyFailuresFile]"
+        }
+        catch {
+            Write-Host "Error writing empty Trivy scan failures file [$trivyFailuresFile]: $($_.Exception.Message)"
+        }
     }
 
     #return ($actions, $existingForks) ? where does this $actions come from?

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -1329,13 +1329,6 @@ function Invoke-TrivyScan {
         $accessToken
     )
 
-    $result = @{
-        critical = 0
-        high = 0
-        lastScanned = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
-        scanError = $null
-    }
-
     # Only scan Docker actions with Dockerfiles (not remote images)
     if ($actionType.actionDockerType -ne "Dockerfile") {
         Write-Debug "Skipping Trivy scan for [$owner/$repo] - not a Dockerfile-based action (type: $($actionType.actionDockerType))"
@@ -1357,8 +1350,7 @@ function Invoke-TrivyScan {
             $trivyPath = Get-Command trivy -ErrorAction SilentlyContinue
             if (-not $trivyPath) {
                 Write-Host "Failed to install Trivy for [$owner/$repo]"
-                $result.scanError = "Trivy installation failed"
-                return $result
+                return $null
             }
         }
 
@@ -1384,8 +1376,7 @@ function Invoke-TrivyScan {
 
             if (-not $dockerFile -or -not $dockerFile.download_url) {
                 Write-Host "Could not retrieve Dockerfile for [$owner/$repo]"
-                $result.scanError = "Dockerfile not found"
-                return $result
+                return $null
             }
 
             # Download Dockerfile content
@@ -1404,8 +1395,7 @@ function Invoke-TrivyScan {
                 
                 if ($LASTEXITCODE -ne 0) {
                     Write-Host "Trivy scan failed for [$owner/$repo]: $scanOutput"
-                    $result.scanError = "Trivy scan failed"
-                    return $result
+                    return $null
                 }
             }
             
@@ -1413,6 +1403,13 @@ function Invoke-TrivyScan {
             try {
                 $scanResults = $scanOutput | ConvertFrom-Json
                 
+                $result = @{
+                    critical = 0
+                    high = 0
+                    lastScanned = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+                    scanError = $null
+                }
+
                 # Count vulnerabilities by severity
                 if ($scanResults.Results) {
                     foreach ($target in $scanResults.Results) {
@@ -1440,10 +1437,11 @@ function Invoke-TrivyScan {
                 }
                 
                 Write-Host "Trivy scan completed for [$owner/$repo]: Critical=$($result.critical), High=$($result.high)"
+                return $result
             }
             catch {
                 Write-Host "Failed to parse Trivy output for [$owner/$repo]: $($_.Exception.Message)"
-                $result.scanError = "Failed to parse Trivy output"
+                return $null
             }
         }
         finally {
@@ -1455,10 +1453,10 @@ function Invoke-TrivyScan {
     }
     catch {
         Write-Host "Error during Trivy scan for [$owner/$repo]: $($_.Exception.Message)"
-        $result.scanError = $_.Exception.Message
+        return $null
     }
 
-    return $result
+    return $null
 }
 
 function GetMoreInfo {
@@ -1823,6 +1821,9 @@ function GetMoreInfo {
                                 Write-Host "Updating container scan information with critical:[$($scanResult.critical)], high:[$($scanResult.high)] for [$($owner)/$($repo))]"
                                 $action.actionType.containerScan = $scanResult
                             }
+                        }
+                        else {
+                            Write-Host "Trivy scan did not complete for [$($owner)/$($repo)]; result will not be stored and will be retried"
                         }
                     }
                     catch {

--- a/.github/workflows/repoInfo.yml
+++ b/.github/workflows/repoInfo.yml
@@ -125,14 +125,46 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-     - name: Upload Trivy scan failures as artifact
-       if: always()
-       uses: actions/upload-artifact@v7
-       with:
-         name: trivy-scan-failures
-         path: trivy-scan-failures.json
-         retention-days: 7
-         if-no-files-found: ignore
+      - name: Summarize Trivy scan failures
+        if: always()
+        shell: pwsh
+        run: |
+          $failuresFile = "trivy-scan-failures.json"
+          if (-not (Test-Path $failuresFile)) {
+            Write-Host "No Trivy scan failures file found at [$failuresFile]"
+            exit 0
+          }
+
+          $content = Get-Content $failuresFile -Raw
+          $failures = $content | ConvertFrom-Json
+          $count = if ($failures -is [array]) { $failures.Count } else { 0 }
+
+          $summary = "## Trivy scan failures`n`n"
+          $summary += "Total failures: $count`n`n"
+          if ($count -gt 0) {
+            $summary += "| owner/repo | docker source | error |`n"
+            $summary += "|------------|---------------|-------|`n"
+            $failures | Select-Object -First 5 | ForEach-Object {
+              $summary += "| $($_.ownerRepo) | $($_.dockerSource) | $($_.error) |`n"
+            }
+            if ($count -gt 5) {
+              $summary += "`n... and $($count - 5) more. See the `trivy-scan-failures` artifact for the full list.`n"
+            }
+          }
+          else {
+            $summary += "No Trivy scan failures recorded in this run.`n"
+          }
+
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload Trivy scan failures as artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-scan-failures
+          path: trivy-scan-failures.json
+          retention-days: 7
+          if-no-files-found: ignore
 
   upload-changes:
     name: Consolidate and upload changes to blob storage

--- a/.github/workflows/repoInfo.yml
+++ b/.github/workflows/repoInfo.yml
@@ -125,6 +125,15 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+     - name: Upload Trivy scan failures as artifact
+       if: always()
+       uses: actions/upload-artifact@v7
+       with:
+         name: trivy-scan-failures
+         path: trivy-scan-failures.json
+         retention-days: 7
+         if-no-files-found: ignore
+
   upload-changes:
     name: Consolidate and upload changes to blob storage
     needs: process-repo-info

--- a/.github/workflows/report.ps1
+++ b/.github/workflows/report.ps1
@@ -30,6 +30,7 @@ $global:localDockerFile = 0
 $global:remoteDockerfile = 0
 $global:localDockerfileWithCustomCode = 0
 $global:localDockerfileWithoutCustomCode = 0
+$global:remoteDockerfileWithReference = 0
 $global:actionYmlFile = 0
 $global:actionYamlFile = 0
 $global:actionDockerFile = 0
@@ -49,6 +50,8 @@ $global:sumDaysOld = 0
 $global:archived = 0
 # string array to hold all used docker base images:
 $global:dockerBaseImages = @()
+# string array to hold all remote docker image references:
+$global:dockerRemoteImageReferences = @()
 $global:nodeVersions = @()
 $global:maxRepoSize = 0
 $global:sumRepoSize = 0
@@ -118,6 +121,10 @@ function AnalyzeActionInformation {
                 }
                 elseif ($action.actionType.actionDockerType -eq "Image") {
                     $global:remoteDockerfile++
+                    if ($action.actionType.dockerImageReference) {
+                        $global:remoteDockerfileWithReference++
+                        $global:dockerRemoteImageReferences += $action.actionType.dockerImageReference
+                    }
                 }
 
                 if ($action.actionType.dockerBaseImage) {
@@ -525,6 +532,15 @@ function ReportInsightsInMarkdown {
     # summarize the string list dockerBaseImages to count each item
     $dockerBaseImagesGrouped = $global:dockerBaseImages | Group-Object | Sort-Object -Descending -Property Count | Select-Object -Property Name, Count
     $dockerBaseImagesGrouped | Sort-Object -Property Count -Descending | Select-Object -First 10 | ForEach-Object {
+        LogMessage "- $($_.Name): $($_.Count)"
+    }
+    LogMessage ""
+
+    LogMessage "## Docker based actions, remote image references: "
+    $dockerRemoteImageReferencesUnique = $dockerRemoteImageReferences | Sort-Object | Get-Unique
+    LogMessage "Found $(DisplayIntWithDots($global:remoteDockerfileWithReference)) remote image actions with $(DisplayIntWithDots($dockerRemoteImageReferencesUnique.Length)) unique image references. The top 10 are listed below."
+    $dockerRemoteImageReferencesGrouped = $global:dockerRemoteImageReferences | Group-Object | Sort-Object -Descending -Property Count | Select-Object -Property Name, Count
+    $dockerRemoteImageReferencesGrouped | Sort-Object -Property Count -Descending | Select-Object -First 10 | ForEach-Object {
         LogMessage "- $($_.Name): $($_.Count)"
     }
     LogMessage ""

--- a/.github/workflows/validate-status-schema.ps1
+++ b/.github/workflows/validate-status-schema.ps1
@@ -131,7 +131,7 @@ function Test-ActionSchema {
     # Validate actionType structure if present
     if ($null -ne $action.actionType) {
         if ($action.actionType -is [hashtable] -or $action.actionType -is [PSCustomObject]) {
-            # Expected fields: fileFound, actionType, nodeVersion, actionDockerType, dockerBaseImage, dockerfileHasCustomCode, containerScan (all optional)
+            # Expected fields: fileFound, actionType, nodeVersion, actionDockerType, dockerImageReference, dockerBaseImage, dockerfileHasCustomCode, containerScan (all optional)
             # These are all optional as content varies
             
             # Validate containerScan structure if present (for Docker actions)

--- a/tests/dockerImageReference.Tests.ps1
+++ b/tests/dockerImageReference.Tests.ps1
@@ -1,0 +1,196 @@
+BeforeAll {
+    # Mock Write-Message function
+    function Write-Message {
+        Param (
+            [string] $message,
+            [bool] $logToSummary = $false
+        )
+        Write-Host $message
+    }
+
+    # Copy the function under test to avoid loading repoInfo.ps1's script-level code
+    function GetRepoDockerBaseImage {
+        Param (
+            [string] $owner,
+            [string] $repo,
+            $actionType,
+            [Alias('access_token')]
+            $accessToken
+        )
+
+        $result = @{
+            dockerBaseImage = ""
+            hasCustomCode = $false
+        }
+
+        if ($actionType.actionDockerType -eq "Image") {
+            # Remote image actions reference an image in action.yml; there is no repo-local Dockerfile to analyze here.
+            return $result
+        }
+
+        if ($actionType.actionDockerType -eq "Dockerfile") {
+            $url = "/repos/$owner/$repo/contents/Dockerfile"
+            $repoUrl = "https://github.com/$owner/$repo"
+            $dockerfilePath = "Dockerfile"
+            $contextInfo = "Repository: $repoUrl, File: $dockerfilePath"
+            try {
+                $dockerFile = ApiCall -method GET -url $url -hideFailedCall $true -contextInfo $contextInfo -access_token $accessToken
+                $hasValidDownloadUrl = $null -ne $dockerFile -and $null -ne $dockerFile.download_url -and $dockerFile.download_url -ne ""
+                if ($hasValidDownloadUrl) {
+                    $dockerFileContent = ApiCall -method GET -url $dockerFile.download_url -contextInfo $contextInfo -access_token $accessToken
+                    $result.dockerBaseImage = GetDockerBaseImageNameFromContent -dockerFileContent $dockerFileContent
+                    $result.hasCustomCode = Test-DockerfileHasCustomCode -dockerFileContent $dockerFileContent
+                }
+                else {
+                    Write-Host "Error: No download_url found for Dockerfile in [$owner/$repo]"
+                }
+            }
+            catch {
+                Write-Host "Error getting Dockerfile for [$owner/$repo]: $($_.Exception.Message), trying lowercase file"
+                # retry with lowercase dockerfile name
+                $url = "/repos/$owner/$repo/contents/dockerfile"
+                $dockerfilePath = "dockerfile"
+                $contextInfo = "Repository: $repoUrl, File: $dockerfilePath"
+                try {
+                    $dockerFile = ApiCall -method GET -url $url -hideFailedCall $true -contextInfo $contextInfo -access_token $accessToken
+                    $hasValidDownloadUrl = $null -ne $dockerFile -and $null -ne $dockerFile.download_url -and $dockerFile.download_url -ne ""
+                    if ($hasValidDownloadUrl) {
+                        $dockerFileContent = ApiCall -method GET -url $dockerFile.download_url -contextInfo $contextInfo -access_token $accessToken
+                        $result.dockerBaseImage = GetDockerBaseImageNameFromContent -dockerFileContent $dockerFileContent
+                        $result.hasCustomCode = Test-DockerfileHasCustomCode -dockerFileContent $dockerFileContent
+                    }
+                    else {
+                        Write-Host "Error: No download_url found for dockerfile in [$owner/$repo]"
+                    }
+                }
+                catch {
+                    Write-Host "Error getting dockerfile for [$owner/$repo]: $($_.Exception.Message)"
+                }
+            }
+        }
+        else {
+            Write-Host "Cant load docker base image for action type [$($actionType.actionType)] with [$($actionType.actionDockerType)] in [$owner/$repo]"
+        }
+
+        return $result
+    }
+
+    function GetDockerBaseImageNameFromContent {
+        param ($dockerFileContent)
+        if ($null -eq $dockerFileContent -or "" -eq $dockerFileContent) {
+            return ""
+        }
+        $lines = $dockerFileContent.Split("`n")
+        $firstFromLine = $lines | Where-Object { $_ -like "FROM *" } | Select-Object -First 1
+        if ($firstFromLine) {
+            $firstFromLine = $firstFromLine.Split(" ")[1]
+        }
+        return $firstFromLine.TrimEnd("`r")
+    }
+
+    function Test-DockerfileHasCustomCode {
+        param ([string]$dockerFileContent)
+        if ($null -eq $dockerFileContent -or "" -eq $dockerFileContent) {
+            return $false
+        }
+        $lines = $dockerFileContent.Split("`n") | ForEach-Object { $_.Trim().TrimEnd("`r") }
+        foreach ($line in $lines) {
+            if ($line -match '^COPY\s+(?:--from=\S+\s+)?\S+\s+\S+' -or $line -match '^ADD\s+(?!\s*https?://)\S+\s+\S+') {
+                return $true
+            }
+        }
+        return $false
+    }
+}
+
+Describe "GetRepoDockerBaseImage" {
+    It "Should return empty result for remote image actions without calling ApiCall" {
+        # Arrange
+        $actionType = @{
+            actionType = "Docker"
+            actionDockerType = "Image"
+            dockerImageReference = "docker://hyperngn/github-actions-11ty:latest"
+        }
+        $apiCallInvoked = $false
+        function ApiCall { $apiCallInvoked = $true }
+
+        # Act
+        $result = GetRepoDockerBaseImage -owner "hyperngn" -repo "github-actions-11ty" -actionType $actionType -accessToken "test"
+
+        # Assert
+        $result.dockerBaseImage | Should -Be ""
+        $result.hasCustomCode | Should -Be $false
+        $apiCallInvoked | Should -Be $false
+    }
+
+    It "Should analyze Dockerfile when actionDockerType is Dockerfile" {
+        # Arrange
+        $actionType = @{
+            actionType = "Docker"
+            actionDockerType = "Dockerfile"
+        }
+        function ApiCall {
+            param ([string]$method, [string]$url, $access_token)
+            if ($url -like "*/contents/Dockerfile") {
+                return @{ download_url = "https://raw.githubusercontent.com/test/repo/Dockerfile" }
+            }
+            if ($url -eq "https://raw.githubusercontent.com/test/repo/Dockerfile") {
+                return "FROM alpine:3.14`nCOPY . /app"
+            }
+            return $null
+        }
+
+        # Act
+        $result = GetRepoDockerBaseImage -owner "test" -repo "repo" -actionType $actionType -accessToken "test"
+
+        # Assert
+        $result.dockerBaseImage | Should -Be "alpine:3.14"
+        $result.hasCustomCode | Should -Be $true
+    }
+}
+
+Describe "Docker image reference tracking" {
+    It "Should count remote image actions with references" {
+        # Arrange
+        $forks = @(
+            @{
+                name = "docker-remote-with-ref"
+                actionType = @{
+                    actionType = "Docker"
+                    actionDockerType = "Image"
+                    dockerImageReference = "docker://owner/image:tag"
+                }
+            },
+            @{
+                name = "docker-remote-without-ref"
+                actionType = @{
+                    actionType = "Docker"
+                    actionDockerType = "Image"
+                }
+            },
+            @{
+                name = "docker-local"
+                actionType = @{
+                    actionType = "Docker"
+                    actionDockerType = "Dockerfile"
+                }
+            }
+        )
+
+        # Act
+        $dockerRemoteImage = 0
+        $dockerRemoteImageWithReference = 0
+        foreach ($fork in $forks) {
+            if ($fork.actionType.actionType -eq "Docker" -and $fork.actionType.actionDockerType -eq "Image") {
+                $dockerRemoteImage++
+                if ($fork.actionType.dockerImageReference) {
+                    $dockerRemoteImageWithReference++
+                }
+            }
+        }
+
+        # Assert
+        $dockerRemoteImage | Should -Be 2
+        $dockerRemoteImageWithReference | Should -Be 1
+    }
+}

--- a/tests/trivyScan.Tests.ps1
+++ b/tests/trivyScan.Tests.ps1
@@ -193,7 +193,7 @@ Describe "Trivy scan result handling" {
 
         # Act
         $hasContainerScanField = Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties
-        if ($null -ne $scanResult) {
+        if ($null -ne $scanResult -and $null -eq $scanResult.scanError) {
             if (!$hasContainerScanField) {
                 $action.actionType | Add-Member -Name containerScan -Value $scanResult -MemberType NoteProperty
             }
@@ -215,14 +215,20 @@ Describe "Trivy scan result handling" {
             actionType = @{
                 actionType = "Docker"
                 actionDockerType = "Dockerfile"
+                fileFound = "action.yml"
             }
         }
-        $scanResult = $null
+        $scanResult = @{
+            critical = 0
+            high = 0
+            lastScanned = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+            scanError = "Trivy installation failed"
+        }
+        $trivyScanFailures = @()
 
         # Act
-        $hadContainerScanFieldBefore = $null -ne (Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties)
-        if ($null -ne $scanResult) {
-            $hasContainerScanField = Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties
+        $hasContainerScanField = Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties
+        if ($null -ne $scanResult -and $null -eq $scanResult.scanError) {
             if (!$hasContainerScanField) {
                 $action.actionType | Add-Member -Name containerScan -Value $scanResult -MemberType NoteProperty
             }
@@ -230,9 +236,55 @@ Describe "Trivy scan result handling" {
                 $action.actionType.containerScan = $scanResult
             }
         }
+        elseif ($null -ne $scanResult -and $null -ne $scanResult.scanError) {
+            $dockerSource = if ($action.actionType.fileFound) { $action.actionType.fileFound } else { $action.actionType.actionDockerType }
+            $trivyScanFailures += @{
+                ownerRepo = "$($action.owner)/$($action.name)"
+                dockerSource = $dockerSource
+                error = $scanResult.scanError
+                timestamp = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+            }
+        }
 
         # Assert
-        $hadContainerScanFieldBefore | Should -Be $false
         $action.actionType.PSObject.Properties.Name | Should -Not -Contain "containerScan"
+        $trivyScanFailures.Count | Should -Be 1
+        $trivyScanFailures[0].ownerRepo | Should -Be "test-owner/test-repo"
+        $trivyScanFailures[0].dockerSource | Should -Be "action.yml"
+        $trivyScanFailures[0].error | Should -Be "Trivy installation failed"
+    }
+}
+
+Describe "Trivy scan failure artifact" {
+    It "Should write failures to JSON file" {
+        # Arrange
+        $tempDir = [System.IO.Path]::GetTempPath()
+        $testFile = Join-Path $tempDir "trivy-scan-failures-test.json"
+        if (Test-Path $testFile) {
+            Remove-Item $testFile -Force
+        }
+
+        $trivyScanFailures = @(
+            @{
+                ownerRepo = "owner/repo"
+                dockerSource = "action.yml"
+                error = "Trivy installation failed"
+                timestamp = "2026-07-26T22:00:00.000Z"
+            }
+        )
+
+        # Act
+        $trivyScanFailures | ConvertTo-Json -Depth 5 | Out-File -FilePath $testFile -Encoding UTF8
+
+        # Assert
+        Test-Path $testFile | Should -Be $true
+        $content = Get-Content $testFile -Raw | ConvertFrom-Json
+        $content.Count | Should -Be 1
+        $content[0].ownerRepo | Should -Be "owner/repo"
+        $content[0].dockerSource | Should -Be "action.yml"
+        $content[0].error | Should -Be "Trivy installation failed"
+
+        # Cleanup
+        Remove-Item $testFile -Force
     }
 }

--- a/tests/trivyScan.Tests.ps1
+++ b/tests/trivyScan.Tests.ps1
@@ -172,3 +172,67 @@ Describe "Trivy Container Scan Logic" {
         }
     }
 }
+
+Describe "Trivy scan result handling" {
+    It "Should store successful scan results" {
+        # Arrange
+        $action = @{
+            owner = "test-owner"
+            name = "test-repo"
+            actionType = @{
+                actionType = "Docker"
+                actionDockerType = "Dockerfile"
+            }
+        }
+        $scanResult = @{
+            critical = 2
+            high = 5
+            lastScanned = (Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ")
+            scanError = $null
+        }
+
+        # Act
+        $hasContainerScanField = Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties
+        if ($null -ne $scanResult) {
+            if (!$hasContainerScanField) {
+                $action.actionType | Add-Member -Name containerScan -Value $scanResult -MemberType NoteProperty
+            }
+            else {
+                $action.actionType.containerScan = $scanResult
+            }
+        }
+
+        # Assert
+        $action.actionType.containerScan.critical | Should -Be 2
+        $action.actionType.containerScan.high | Should -Be 5
+    }
+
+    It "Should not store failed scan results so they can be retried" {
+        # Arrange
+        $action = @{
+            owner = "test-owner"
+            name = "test-repo"
+            actionType = @{
+                actionType = "Docker"
+                actionDockerType = "Dockerfile"
+            }
+        }
+        $scanResult = $null
+
+        # Act
+        $hadContainerScanFieldBefore = $null -ne (Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties)
+        if ($null -ne $scanResult) {
+            $hasContainerScanField = Get-Member -inputobject $action.actionType -name "containerScan" -Membertype Properties
+            if (!$hasContainerScanField) {
+                $action.actionType | Add-Member -Name containerScan -Value $scanResult -MemberType NoteProperty
+            }
+            else {
+                $action.actionType.containerScan = $scanResult
+            }
+        }
+
+        # Assert
+        $hadContainerScanFieldBefore | Should -Be $false
+        $action.actionType.PSObject.Properties.Name | Should -Not -Contain "containerScan"
+    }
+}


### PR DESCRIPTION
This change improves how Docker-based actions are analyzed and how Trivy scan failures are surfaced.

## Why
- The scanner logged a misleading error (`Cant load docker base image...`) for actions that use a remote Docker image in `action.yml`, because it always tried to read a repo-local `Dockerfile`.
- When Trivy could not be installed or the scan failed, the result was stored as `critical: 0, high: 0`, hiding the failure and preventing a retry.
- There was no easy way to inspect which Trivy scans failed after a run finished.

## What changed
- `GetActionType` now captures the `runs.image` value from `action.yml` as `dockerImageReference` and stores it on `action.actionType`.
- Dockerfile base-image analysis is now skipped for `Image`-type Docker actions; the remote image reference is logged instead.
- `Invoke-TrivyScan` returns a `scanError`-populated result for every failure path instead of silently storing empty counts.
- Failed Trivy scans are collected into `trivy-scan-failures.json` with `ownerRepo`, `dockerSource`, `error`, and `timestamp`, then uploaded as a workflow artifact.
- A new workflow step appends a summary table (count + first 5 failures) to the GitHub step summary.
- Report and environment-state outputs now track remote Docker image references.

## Notes
- Failed scans are intentionally not written to `containerScan`, so they remain eligible for retry on the next run.
- A new Pester test file (`tests/dockerImageReference.Tests.ps1`) covers the remote-image behavior; existing Trivy tests were updated for the failure-artifact logic.