### PR TITLE
Extract action description from action.yml and upload it

### DIFF
--- a/.github/workflows/node-scripts/src/upload-to-api.js
+++ b/.github/workflows/node-scripts/src/upload-to-api.js
@@ -385,6 +385,7 @@ async function uploadActions() {
     // Add optional fields if they exist in the schema
     // Based on status.json schema documented in validate-status-schema.ps1:
     // - actionType (object/string)
+    // - description (string)
     // - repoInfo (object)
     // - tagInfo, releaseInfo (version information)
     // - forkFound, mirrorLastUpdated, repoSize
@@ -393,6 +394,7 @@ async function uploadActions() {
     // - dependents, verified
     
     if (action.actionType) actionData.actionType = action.actionType;
+    if (action.description) actionData.description = action.description;
     if (action.repoInfo) actionData.repoInfo = action.repoInfo;
     if (action.tagInfo) actionData.tagInfo = action.tagInfo;
     if (action.releaseInfo) actionData.releaseInfo = action.releaseInfo;

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -564,11 +564,11 @@ function GetActionType {
     )
 
     if ($null -eq $owner) {
-        return ("No owner found", "No owner found", "No owner found", $null, "")
+        return ("No owner found", "No owner found", "No owner found", $null, "", $null)
     }
 
     if ($null -eq $repo) {
-        return ("No repo found", "No repo found", "No repo found", $null, "")
+        return ("No repo found", "No repo found", "No repo found", $null, "", $null)
     }
 
     # Check if we are nearing the 50-minute mark
@@ -603,7 +603,7 @@ function GetActionType {
                 $actionDockerType = "Dockerfile"
                 $actionType = "Docker"
 
-                return ($actionType, $fileFound, $actionDockerType, $null, $dockerImageReference)
+                return ($actionType, $fileFound, $actionDockerType, $null, $dockerImageReference, $null)
             }
             catch {
                 try {
@@ -613,11 +613,11 @@ function GetActionType {
                     $actionDockerType = "Dockerfile"
                     $actionType = "Docker"
 
-                    return ($actionType, $fileFound, $actionDockerType, $null, $dockerImageReference)
+                    return ($actionType, $fileFound, $actionDockerType, $null, $dockerImageReference, $null)
                 }
                 catch {
                     Write-Debug "No action.yml or action.yaml or Dockerfile or dockerfile found in repo [$owner/$repo]"
-                    return ("No file found", "No file found", "No file found", $null, $dockerImageReference)
+                    return ("No file found", "No file found", "No file found", $null, $dockerImageReference, $null)
                 }
             }
         }
@@ -625,7 +625,7 @@ function GetActionType {
 
     if ($response.Length -eq 0 -or $response.download_url.Length -eq 0) {
         Write-Debug "No action definition found in repo [$owner/$repo]"
-        return ("No file found", "No file found", "No file found", $null, "")
+        return ("No file found", "No file found", "No file found", $null, "", $null)
     }
 
     # load the file
@@ -648,9 +648,9 @@ function GetActionType {
             }
         }
         
-        return ("Error downloading file", "No file found", "No file found", $null, "")
+        return ("Error downloading file", "No file found", "No file found", $null, "", $null)
     }
-    
+
     Write-Debug "response: $($fileContent)"
     try {
         $yaml = ConvertFrom-Yaml $fileContent
@@ -659,7 +659,14 @@ function GetActionType {
         Write-Host "Error converting to yaml: $($_.Exception.Message)"
         Write-Host "Yaml content repo [$owner/$repo]:"
         Write-Host $fileContent
-        return ("Unknown", "No file found", "No file found", $null, "")
+        return ("Unknown", "No file found", "No file found", $null, "", $null)
+    }
+
+    # The marketplace's free-text search matches on this, so it's worth
+    # carrying even though nothing else in this repo reads it today.
+    $description = $null
+    if ($yaml.description -is [string] -and $yaml.description.Trim().Length -gt 0) {
+        $description = $yaml.description.Trim()
     }
 
     # find line that says "
@@ -695,7 +702,7 @@ function GetActionType {
         }
     }
 
-    return ($actionType, $fileFound, $actionDockerType, $nodeVersion, $dockerImageReference)
+    return ($actionType, $fileFound, $actionDockerType, $nodeVersion, $dockerImageReference, $description)
 }
 
 function CheckForInfoUpdateNeeded {
@@ -703,6 +710,7 @@ function CheckForInfoUpdateNeeded {
         $action,
         $hasActionTypeField,
         $hasNodeVersionField,
+        $hasDescriptionField,
         $startTime
     )
 
@@ -722,6 +730,15 @@ function CheckForInfoUpdateNeeded {
 
     # check nodeVersion field missing for Node actionType
     if (("Node" -eq $action.actionType.actionType) -and !$hasNodeVersionField) {
+        return $true
+    }
+
+    # check description field missing entirely - backfill once, the same way
+    # nodeVersion was backfilled above. Records parsed before this field
+    # existed never got a `description` property (not even a null one), so
+    # this only fires once per record: the parse below always adds the
+    # property, even when the action.yml has no description to report.
+    if (!$hasDescriptionField) {
         return $true
     }
 
@@ -1037,11 +1054,12 @@ function GetInfo {
 
         $hasActionTypeField = Get-Member -inputobject $action -name "actionType" -Membertype Properties
         $hasNodeVersionField = $null -ne $action.actionType.nodeVersion
-        $updateNeeded = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $hasActionTypeField -hasNodeVersionField $hasNodeVersionField -startTime $startTime
+        $hasDescriptionField = $null -ne (Get-Member -inputobject $action -name "description" -Membertype Properties)
+        $updateNeeded = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $hasActionTypeField -hasNodeVersionField $hasNodeVersionField -hasDescriptionField $hasDescriptionField -startTime $startTime
         if ($updateNeeded) {
             ($owner, $repo) = GetOrgActionInfo($action.name)
             Write-Host "$i/$max - Checking action information for [$($owner)/$($repo)]"
-            ($actionTypeResult, $fileFoundResult, $actionDockerTypeResult, $nodeVersion, $dockerImageReference) = GetActionType -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
+            ($actionTypeResult, $fileFoundResult, $actionDockerTypeResult, $nodeVersion, $dockerImageReference, $descriptionResult) = GetActionType -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
 
             If (!$hasActionTypeField) {
                 $actionType = @{
@@ -1077,6 +1095,16 @@ function GetInfo {
                 $repoHadUpdates = $true
             }
 
+            # description is a top-level field (matching the marketplace API's
+            # schema), not nested under actionType. Always (re)written, even to
+            # $null, so hasDescriptionField is true afterward and this record
+            # is not re-parsed on every future run just to re-check it.
+            if (!$hasDescriptionField) {
+                $action | Add-Member -Name description -Value $descriptionResult -MemberType NoteProperty
+            }
+            else {
+                $action.description = $descriptionResult
+            }
         }
 
         # store funding information

--- a/.github/workflows/validate-status-schema.ps1
+++ b/.github/workflows/validate-status-schema.ps1
@@ -58,7 +58,10 @@ class StatusJsonSchema {
     
     # Action type information (typically present but can have varied content)
     [object] $actionType  # Hashtable with fileFound, actionType, nodeVersion, actionDockerType, dockerBaseImage, dockerfileHasCustomCode, containerScan
-    
+
+    # Short blurb from the action's action.yml (optional, null when not found or not yet parsed)
+    [object] $description
+
     # Repository information (typically present)
     [object] $repoInfo  # Hashtable with disabled, archived, updated_at, latest_release_published_at
     

--- a/tests/actionTypeRecheck.Tests.ps1
+++ b/tests/actionTypeRecheck.Tests.ps1
@@ -6,6 +6,7 @@ BeforeAll {
             $action,
             $hasActionTypeField,
             $hasNodeVersionField,
+            $hasDescriptionField,
             $startTime
         )
 
@@ -25,6 +26,11 @@ BeforeAll {
 
         # check nodeVersion field missing for Node actionType
         if (("Node" -eq $action.actionType.actionType) -and !$hasNodeVersionField) {
+            return $true
+        }
+
+        # check description field missing entirely - backfill once
+        if (!$hasDescriptionField) {
             return $true
         }
 
@@ -75,7 +81,7 @@ Describe "CheckForInfoUpdateNeeded ties action re-parsing to repo change date" {
                 nodeVersion = "16"
             }
         }
-        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $true -startTime (Get-Date)
         $result | Should -Be $true
     }
 
@@ -90,7 +96,7 @@ Describe "CheckForInfoUpdateNeeded ties action re-parsing to repo change date" {
                 repoUpdatedAt = "2024-01-10T10:00:00Z"
             }
         }
-        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $true -startTime (Get-Date)
         $result | Should -Be $true
     }
 
@@ -105,7 +111,7 @@ Describe "CheckForInfoUpdateNeeded ties action re-parsing to repo change date" {
                 repoUpdatedAt = "2024-01-10T10:00:00Z"
             }
         }
-        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $true -startTime (Get-Date)
         $result | Should -Be $false
     }
 
@@ -120,7 +126,7 @@ Describe "CheckForInfoUpdateNeeded ties action re-parsing to repo change date" {
                 repoUpdatedAt = "2024-01-10T10:00:00Z"
             }
         }
-        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $true -startTime (Get-Date)
         $result | Should -Be $false
     }
 
@@ -135,7 +141,40 @@ Describe "CheckForInfoUpdateNeeded ties action re-parsing to repo change date" {
                 repoUpdatedAt = "changed-marker-a"
             }
         }
-        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -startTime (Get-Date)
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $true -startTime (Get-Date)
         $result | Should -Be $true
+    }
+}
+
+Describe "CheckForInfoUpdateNeeded backfills a missing description field" {
+    It "requests an update for a record that has never had a description property" {
+        $action = [PSCustomObject]@{
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = "2024-01-10T10:00:00Z"
+            actionType = [PSCustomObject]@{
+                actionType    = "Node"
+                nodeVersion   = "24"
+                repoUpdatedAt = "2024-01-10T10:00:00Z"
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $false -startTime (Get-Date)
+        $result | Should -Be $true
+    }
+
+    It "does not request an update when description is already present, even as null" {
+        $action = [PSCustomObject]@{
+            name              = "actions/checkout"
+            mirrorFound       = $true
+            mirrorLastUpdated = "2024-01-10T10:00:00Z"
+            description       = $null
+            actionType = [PSCustomObject]@{
+                actionType    = "Node"
+                nodeVersion   = "24"
+                repoUpdatedAt = "2024-01-10T10:00:00Z"
+            }
+        }
+        $result = CheckForInfoUpdateNeeded -action $action -hasActionTypeField $true -hasNodeVersionField $true -hasDescriptionField $true -startTime (Get-Date)
+        $result | Should -Be $false
     }
 }

--- a/tests/apiUpsert.Tests.ps1
+++ b/tests/apiUpsert.Tests.ps1
@@ -99,8 +99,12 @@ Describe "API Upsert Script" {
             $nodeScript | Should -Match 'action\.actionType'
             $nodeScript | Should -Match 'action\.repoInfo'
             $nodeScript | Should -Match 'action\.vulnerabilityStatus'
+            # description is a documented top-level field in the marketplace
+            # API's Action Data Schema (src/backend/README.md in the
+            # alternative-github-actions-marketplace repo) - repoInfo.ps1 now
+            # extracts it from action.yml, so it's no longer an invented field.
+            $nodeScript | Should -Match 'action\.description'
             # Ensure it doesn't use invented fields
-            $nodeScript | Should -Not -Match 'actionData\.description'
             $nodeScript | Should -Not -Match 'actionData\.icon'
             $nodeScript | Should -Not -Match 'actionData\.color'
         }


### PR DESCRIPTION
## Summary
Companion to three PRs on `devops-actions/alternative-github-actions-marketplace` that make search match on action `description`, not just owner/name:
- backend: devops-actions/alternative-github-actions-marketplace#254
- VS Code extension: devops-actions/alternative-github-actions-marketplace#255
- website: devops-actions/alternative-github-actions-marketplace#256

Those three add `description` end-to-end and gracefully treat it as `null`/unknown until it's populated - this PR is the missing piece that actually populates it, since nothing here previously extracted it from `action.yml`.

## Changes
- `GetActionType` (`repoInfo.ps1`) now reads `$yaml.description` alongside the existing `runs.using` parsing and returns it as a 6th tuple element.
- `CheckForInfoUpdateNeeded` gained a `hasDescriptionField` check, mirroring how the `nodeVersion` field was backfilled when it was added: existing records get a one-time re-parse to pick up `description`, then it's written (even as `null`) so they're not re-checked forever.
- `description` is stored as a **top-level** property on the action record (matching the marketplace API's documented schema), not nested under `actionType`.
- `upload-to-api.js` forwards `action.description` to `actionData.description`, same as it already does for `actionType`/`repoInfo`.
- `validate-status-schema.ps1`'s schema docs updated to mention the new field.
- Updated `apiUpsert.Tests.ps1`'s guard test, which previously asserted `actionData.description` must never appear (back when it was an invented field not in the API schema) - it's documented in `src/backend/README.md`'s Action Data Schema now.

## Test plan
- [x] `Invoke-Pester -Path tests` - 688/693 passing; the 2 remaining failures (`Select-ForksToProcess` prioritization, Trivy scan timing) reproduce identically on a clean `origin/main` checkout with none of this PR's changes, so they're pre-existing/unrelated
- [x] `Invoke-Pester -Path tests/actionTypeRecheck.Tests.ps1` and `tests/apiUpsert.Tests.ps1` - all green, including new description-backfill test cases
- [x] `node --test .github/workflows/node-scripts/test/upload-to-api.test.js` - 6/6 passing
- [x] PowerShell parser check on `repoInfo.ps1` and `validate-status-schema.ps1` - no syntax errors