### PR TITLE
Add dedicated description backfill workflow

### DIFF
--- a/.github/workflows/description-backfill.ps1
+++ b/.github/workflows/description-backfill.ps1
@@ -1,0 +1,207 @@
+Param (
+    $accessToken = $env:GITHUB_TOKEN,
+    # Hard safety margin below GitHub-hosted runners' 6 hour job cap. We stop
+    # starting new work (including new rate-limit waits) once we're within
+    # this margin, so a clean SaveStatus always happens before the runner's
+    # own timeout could kill the job mid-write.
+    $maxRuntimeMinutes = 340,
+    # Longest single rate-limit wait ApiCall will take before switching apps
+    # or stopping gracefully (see library.ps1). Used to make sure we never
+    # start an iteration that could still be waiting when we cross the
+    # maxRuntimeMinutes mark.
+    $maxSingleWaitMinutes = 20
+)
+
+# Dedicated, low-overhead backfill for the `description` field only.
+#
+# Context: repoInfo.ps1's main pipeline (GetInfo/GetMoreInfo) backfills
+# description as a side effect of its regular per-repo bookkeeping, but that
+# pipeline shares its GitHub Apps and per-run update budget with three other
+# hourly workflows (analyze, releaseInfo-refresh, update-mirrors), and does a
+# lot of unrelated work (owner backfill, mirrorLastUpdated, repoSize,
+# dependents refresh, Trivy scans) per repo before it ever reaches the
+# description check. That crowds out the description backfill and burns
+# through the shared rate limit before real progress is made.
+#
+# This script instead:
+# - runs on its own dedicated GitHub App (isolated rate-limit pool - see
+#   description-backfill.yml), so it never contends with the other workflows
+# - only targets records that are missing a description AND already have a
+#   known action.yml/action.yaml path from a previous repoInfo.ps1 run, so
+#   each repo costs exactly 2 API calls (contents metadata + raw file
+#   download) instead of the 4-6+ calls GetActionType needs when probing for
+#   the file from scratch
+# - is time-budget bound (not repo-count bound), so it can use as much of a
+#   single long-running job as the rate limit allows
+
+. $PSScriptRoot/library.ps1
+
+$startTime = Get-Date
+Write-Host "Description backfill run started at [$startTime]"
+Write-Host "Max runtime: [$maxRuntimeMinutes] minutes (safety margin below the 6 hour job cap)"
+
+if ([string]::IsNullOrWhiteSpace($accessToken)) {
+    try {
+        $tokenManager = New-GitHubAppTokenManagerFromEnvironment
+        $script:GitHubAppTokenManagerInstance = $tokenManager
+        $tokenResult = $tokenManager.GetTokenForOrganization($env:APP_ORGANIZATION)
+        $accessToken = $tokenResult.Token
+    }
+    catch {
+        Write-Error "Failed to obtain GitHub App token for organization [$($env:APP_ORGANIZATION)]: $($_.Exception.Message)"
+        throw
+    }
+}
+$env:GITHUB_TOKEN = $accessToken
+
+Import-Module powershell-yaml -Force
+
+if (-not (Test-Path $statusFile)) {
+    Write-Error "No status.json found at [$statusFile] - nothing to backfill. Did the 'Download status.json from blob storage' step run?"
+    exit 1
+}
+
+Write-Host "Loading existing status from [$statusFile]"
+$existingForks = Get-Content $statusFile | ConvertFrom-Json
+$existingForks = Normalize-ActionDates -actions $existingForks
+Write-Host "Loaded [$(DisplayIntWithDots $existingForks.Count)] existing records"
+
+# Candidates: no description yet, but we already know exactly which file to
+# read it from. Anything with fileFound in ("No file found", "Error
+# downloading file", "Unknown", $null, "Dockerfile", "dockerfile") has no
+# action.yml/action.yaml to read a description from, so skip those instead
+# of spending a wasted API call on them.
+$eligibleFileNames = @("action.yml", "action.yaml")
+$candidates = @($existingForks | Where-Object {
+    $hasDescriptionField = $null -ne (Get-Member -InputObject $_ -Name "description" -MemberType Properties)
+    $hasDescriptionValue = $hasDescriptionField -and ($null -ne $_.description) -and ("$($_.description)".Trim().Length -gt 0)
+    $fileFound = $_.actionType.fileFound
+    (-not $hasDescriptionValue) -and ($null -ne $fileFound) -and ($eligibleFileNames -contains $fileFound)
+})
+
+Write-Message -message "# Description Backfill" -logToSummary $true
+Write-Message -message "" -logToSummary $true
+Write-Message -message "Found [$(DisplayIntWithDots $candidates.Count)] candidates missing a description with a known action.yml/action.yaml path (out of [$(DisplayIntWithDots $existingForks.Count)] total records)" -logToSummary $true
+
+$processed = 0
+$updated = 0
+$notFound = 0
+$errors = 0
+$stoppedEarly = $false
+$stopReason = ""
+
+foreach ($action in $candidates) {
+    $timeSpan = (Get-Date) - $startTime
+    $remainingMinutes = $maxRuntimeMinutes - $timeSpan.TotalMinutes
+    if ($remainingMinutes -le $maxSingleWaitMinutes) {
+        # Not enough runway left to safely start another iteration that
+        # might need to wait out a rate limit reset. Stop now so SaveStatus
+        # below always completes well inside the runner's own timeout.
+        $stoppedEarly = $true
+        $stopReason = "Approaching the [$maxRuntimeMinutes] minute safety margin (elapsed [$([math]::Round($timeSpan.TotalMinutes, 1))] minutes)"
+        Write-Host "Stopping: $stopReason"
+        break
+    }
+
+    $processed++
+    ($owner, $repo) = GetOrgActionInfo($action.name)
+    if ([string]::IsNullOrWhiteSpace($owner) -or [string]::IsNullOrWhiteSpace($repo)) {
+        continue
+    }
+
+    $fileFound = $action.actionType.fileFound
+
+    try {
+        $url = "/repos/$owner/$repo/contents/$fileFound"
+        $response = ApiCall -method GET -url $url -hideFailedCall $true -access_token $accessToken
+
+        if ($null -eq $response -or [string]::IsNullOrWhiteSpace($response.download_url)) {
+            $notFound++
+            continue
+        }
+
+        $fileContent = ApiCall -method GET -url $response.download_url -returnErrorInfo $true -access_token $accessToken
+        if (($fileContent -is [hashtable]) -and ($fileContent.ContainsKey('Error'))) {
+            Write-Debug "Error downloading [$fileFound] for [$owner/$repo]: StatusCode $($fileContent.StatusCode)"
+            $errors++
+            continue
+        }
+
+        $yaml = $null
+        try {
+            $yaml = ConvertFrom-Yaml $fileContent
+        }
+        catch {
+            Write-Debug "Error converting [$owner/$repo] [$fileFound] to yaml: $($_.Exception.Message)"
+            $errors++
+            continue
+        }
+
+        $description = $null
+        if ($yaml.description -is [string] -and $yaml.description.Trim().Length -gt 0) {
+            $description = $yaml.description.Trim()
+        }
+
+        # Always write the property, even when $null. This marks the record
+        # as "checked" (hasDescriptionField becomes true), matching the same
+        # "null means unknown, not empty" convention repoInfo.ps1 already
+        # uses, so this record is not re-selected as a candidate next run.
+        $hasField = Get-Member -InputObject $action -Name "description" -MemberType Properties
+        if (-not $hasField) {
+            $action | Add-Member -Name description -Value $description -MemberType NoteProperty
+        }
+        else {
+            $action.description = $description
+        }
+
+        if ($null -ne $description) {
+            $updated++
+        }
+        else {
+            $notFound++
+        }
+    }
+    catch {
+        Write-Debug "Unexpected error processing [$owner/$repo]: $($_.Exception.Message)"
+        $errors++
+    }
+
+    if ($processed % 500 -eq 0) {
+        $elapsed = [math]::Round(((Get-Date) - $startTime).TotalMinutes, 1)
+        Write-Host "Progress: processed [$processed] of [$($candidates.Count)] candidates ([$updated] descriptions found, [$notFound] blank, [$errors] errors) - elapsed [$elapsed] min"
+        # Checkpoint periodically so a crash or an unexpected kill doesn't
+        # lose several hours of API calls we already paid for.
+        SaveStatus -existingForks $existingForks
+    }
+}
+
+$totalElapsedMinutes = [math]::Round(((Get-Date) - $startTime).TotalMinutes, 1)
+
+Write-Host ""
+Write-Host "Description backfill finished: processed [$processed] of [$($candidates.Count)] candidates in [$totalElapsedMinutes] minutes"
+Write-Host "  Descriptions found: $updated"
+Write-Host "  Confirmed blank/unavailable: $notFound"
+Write-Host "  Errors: $errors"
+if ($stoppedEarly) {
+    Write-Host "  Stopped early: $stopReason"
+}
+
+Write-Message -message "" -logToSummary $true
+Write-Message -message "| Metric | Count |" -logToSummary $true
+Write-Message -message "|--------|------:|" -logToSummary $true
+Write-Message -message "| Candidates found | $(DisplayIntWithDots $candidates.Count) |" -logToSummary $true
+Write-Message -message "| Processed this run | $(DisplayIntWithDots $processed) |" -logToSummary $true
+Write-Message -message "| ✅ Descriptions found | $(DisplayIntWithDots $updated) |" -logToSummary $true
+Write-Message -message "| ⬜ Confirmed blank | $(DisplayIntWithDots $notFound) |" -logToSummary $true
+Write-Message -message "| ❌ Errors | $(DisplayIntWithDots $errors) |" -logToSummary $true
+Write-Message -message "| ⏱️ Elapsed minutes | $totalElapsedMinutes |" -logToSummary $true
+if ($stoppedEarly) {
+    Write-Message -message "" -logToSummary $true
+    Write-Message -message "⚠️ Stopped early: $stopReason. Remaining [$(DisplayIntWithDots ($candidates.Count - $processed))] candidates will be picked up on the next scheduled run." -logToSummary $true
+}
+
+SaveStatus -existingForks $existingForks
+
+GetRateLimitInfo -access_token $accessToken -access_token_destination $accessToken -waitForRateLimit $false
+
+exit 0

--- a/.github/workflows/description-backfill.ps1
+++ b/.github/workflows/description-backfill.ps1
@@ -41,6 +41,17 @@ Write-Host "Description backfill run started at [$startTime]"
 Write-Host "Max runtime: [$maxRuntimeMinutes] minutes (safety margin below the 6 hour job cap)"
 
 if ([string]::IsNullOrWhiteSpace($accessToken)) {
+    # Fail fast on an obviously-bad key (e.g. a placeholder value, or the app
+    # ID/path pasted by mistake) before ever attempting a token exchange or
+    # processing a single candidate. This is the exact scenario that let a
+    # prior run burn its whole time budget doing nothing useful: the app
+    # secret was still a placeholder, but the script kept iterating through
+    # ~29,000 candidates anyway.
+    if (-not (Test-IsLikelyGitHubAppPemKey -pemKey $env:APPLICATION_PRIVATE_KEY)) {
+        Write-Error "APPLICATION_PRIVATE_KEY does not look like a PEM-encoded GitHub App private key (missing a '-----BEGIN ... PRIVATE KEY-----' header, or too short). Refusing to start the backfill - update the AUTOMATION_APP_KEY4 secret with the real private key contents before re-running."
+        exit 1
+    }
+
     try {
         $tokenManager = New-GitHubAppTokenManagerFromEnvironment
         $script:GitHubAppTokenManagerInstance = $tokenManager
@@ -53,6 +64,32 @@ if ([string]::IsNullOrWhiteSpace($accessToken)) {
     }
 }
 $env:GITHUB_TOKEN = $accessToken
+
+# Second guard: confirm the token we got back actually authenticates as the
+# GitHub App, rather than trusting that a non-empty token is a working one.
+# An unauthenticated/failed token still reports a real (very low) rate limit
+# via api.github.com/rate_limit, so we can detect it cheaply with a single
+# call instead of discovering it thousands of failed candidates later.
+try {
+    $rateLimitCheck = Invoke-RestMethod -Uri "https://api.github.com/rate_limit" -Headers @{
+        Authorization = "Bearer $accessToken"
+        Accept        = "application/vnd.github+json"
+    } -Method GET -ErrorAction Stop
+}
+catch {
+    Write-Error "Startup credential check failed: could not call GET /rate_limit with the obtained token ($($_.Exception.Message)). Refusing to start the backfill - verify APP_ID/APPLICATION_PRIVATE_KEY (AUTOMATION_APP_KEY4) are correct and the app is installed on [$($env:APP_ORGANIZATION)]."
+    exit 1
+}
+
+$coreLimit = $rateLimitCheck.resources.core.limit
+Write-Host "Startup credential check OK - authenticated core rate limit is [$(DisplayIntWithDots $coreLimit)] requests/hour"
+if ($coreLimit -le 60) {
+    # 60/hour is the standard unauthenticated limit - seeing exactly that
+    # means the token did not actually authenticate as the App/installation,
+    # even though we received a non-empty token string.
+    Write-Error "Startup credential check failed: authenticated core rate limit is only [$coreLimit] requests/hour, which means the token is not actually authenticated as the GitHub App (this is the standard unauthenticated limit). Refusing to start the backfill - verify APP_ID/APPLICATION_PRIVATE_KEY (AUTOMATION_APP_KEY4) are correct and the app is installed on [$($env:APP_ORGANIZATION)]."
+    exit 1
+}
 
 Import-Module powershell-yaml -Force
 

--- a/.github/workflows/description-backfill.yml
+++ b/.github/workflows/description-backfill.yml
@@ -1,0 +1,266 @@
+# Dedicated backfill for the `description` field on existing action records.
+#
+# Split out from repoInfo.yml/repoInfo.ps1 because that pipeline shares its 3
+# GitHub Apps and a per-run update budget with 3 other hourly workflows, which
+# left description backfill starved of both API calls and time budget (see
+# https://github.com/rajbos/actions-marketplace-checks/pull/244 for the
+# extraction logic this reuses, and .github/RATE_LIMIT_ARCHITECTURE.md for the
+# rate limit background).
+#
+# This workflow runs on its own dedicated 4th GitHub App/rate-limit pool
+# (APPLICATION_ID_4 / AUTOMATION_APP_KEY4, installed on the same
+# actions-marketplace-validations org) so it never contends with the other
+# hourly workflows, and only fetches the single already-known
+# action.yml/action.yaml file per repo instead of re-probing from scratch.
+
+name: Description backfill
+
+on:
+  push:
+    paths:
+      - .github/workflows/description-backfill.yml
+      - .github/workflows/description-backfill.ps1
+
+  schedule:
+     # Runs every 6 hours, offset from the other hourly workflows
+     # (analyze :05, releaseInfo-refresh :20, update-mirrors :35, repoInfo :50)
+     # so it never starts in the same minute as any of them.
+     - cron: '15 */6 * * *'
+
+  workflow_dispatch:
+
+# Prevent concurrent runs of this workflow - it's a single long-running job.
+concurrency:
+  group: description-backfill-workflow
+  cancel-in-progress: false
+
+env:
+  # Isolated 4th GitHub App - deliberately NOT setting APP_ID_2/APP_ID_3 here
+  # so this workflow can never fall back to (and contend for) the other 3
+  # apps used by analyze/releaseInfo-refresh/update-mirrors/repoInfo.
+  APP_ID: ${{ vars.APPLICATION_ID_4 }}
+  APP_ORGANIZATION: actions-marketplace-validations
+
+jobs:
+  process-description-backfill:
+    runs-on: ubuntu-latest
+    # Hard backstop below GitHub-hosted runners' 6 hour job cap. The script's
+    # own ~340 minute internal guard should always stop it before this fires;
+    # this is only a safety net if that guard is ever bypassed.
+    timeout-minutes: 355
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download status.json from blob storage
+        shell: pwsh
+        env:
+          BLOB_SAS_TOKEN: "${{ secrets.BLOB_SAS_TOKEN }}"
+        run: |
+          . ./.github/workflows/library.ps1
+          $result = Get-StatusFromBlobStorage -sasToken $env:BLOB_SAS_TOKEN
+          if (-not $result) {
+            Write-Error "Failed to download status.json from blob storage"
+            exit 1
+          }
+
+      - shell: pwsh
+        name: Backfill descriptions
+        env:
+          APPLICATION_PRIVATE_KEY: ${{ secrets.AUTOMATION_APP_KEY4 }}
+        run: |
+          . "${{ github.workspace }}/.github/workflows/library.ps1"
+          Install-ModuleWithRetry -ModuleName "powershell-yaml"
+          & "${{ github.workspace }}/.github/workflows/description-backfill.ps1"
+
+      - name: Upload updated status.json as artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: status-updated
+          path: status.json
+          retention-days: 1
+
+  upload-changes:
+    name: Consolidate and upload changes to blob storage
+    needs: process-description-backfill
+    if: always()
+    runs-on: ubuntu-latest
+    concurrency:
+      group: repo-state-updates
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download latest status.json from blob storage
+        shell: pwsh
+        env:
+          BLOB_SAS_TOKEN: "${{ secrets.BLOB_SAS_TOKEN }}"
+        run: |
+          . ./.github/workflows/library.ps1
+          $result = Get-StatusFromBlobStorage -sasToken $env:BLOB_SAS_TOKEN
+          if (-not $result) {
+            Write-Error "Failed to download status.json from blob storage"
+            exit 1
+          }
+
+      - name: Download updated status from previous job
+        uses: actions/download-artifact@v8
+        with:
+          name: status-updated
+          path: updated-data/
+
+      - name: Merge changes from processing job
+        shell: pwsh
+        run: |
+          . ./.github/workflows/library.ps1
+
+          Write-Message -message "# Consolidating Description Backfill Changes" -logToSummary $true
+          Write-Message -message "" -logToSummary $true
+
+          # Load current status from blob storage
+          try {
+              $jsonContent = Get-Content status.json -Raw
+              $jsonContent = $jsonContent -replace '^\uFEFF', ''
+              $currentStatus = $jsonContent | ConvertFrom-Json
+          } catch {
+              Write-Error "Failed to parse current status.json: $($_.Exception.Message)"
+              exit 1
+          }
+
+          Write-Message -message "Loaded current status from blob storage with [$(DisplayIntWithDots $currentStatus.Count)] forks" -logToSummary $true
+
+          # Load updated status from processing job
+          $updatedStatusFile = "updated-data/status.json"
+          if (Test-Path $updatedStatusFile) {
+              try {
+                  $updatedContent = Get-Content $updatedStatusFile -Raw
+                  $updatedContent = $updatedContent -replace '^\uFEFF', ''
+                  $updatedStatus = $updatedContent | ConvertFrom-Json
+                  Write-Message -message "Loaded updated status from processing job with [$(DisplayIntWithDots $updatedStatus.Count)] forks" -logToSummary $true
+              } catch {
+                  Write-Error "Failed to parse updated status.json: $($_.Exception.Message)"
+                  exit 1
+              }
+
+              # Create hashtable for fast lookup
+              $statusByName = @{}
+              foreach ($item in $currentStatus) {
+                  $statusByName[$item.name] = $item
+              }
+
+              # Merge updates - copy all properties from updated forks
+              $mergeCount = 0
+              foreach ($updatedFork in $updatedStatus) {
+                  if ($statusByName.ContainsKey($updatedFork.name)) {
+                      # Update existing entry - copy all properties from updated fork
+                      $existing = $statusByName[$updatedFork.name]
+
+                      foreach ($prop in $updatedFork.PSObject.Properties) {
+                          $propName = $prop.Name
+                          $propValue = $prop.Value
+
+                          $existingProp = $existing.PSObject.Properties[$propName]
+                          if ($existingProp) {
+                              $existingProp.Value = $propValue
+                          } else {
+                              $existing | Add-Member -Name $propName -Value $propValue -MemberType NoteProperty -Force
+                          }
+                      }
+                      $mergeCount++
+                  } else {
+                      # Add new entry
+                      $statusByName[$updatedFork.name] = $updatedFork
+                      $mergeCount++
+                  }
+              }
+
+              Write-Message -message "Merged [$(DisplayIntWithDots $mergeCount)] fork updates into current status" -logToSummary $true
+
+              # Convert back to array and save
+              $mergedStatus = $statusByName.Values
+              Write-Message -message "Saving merged status with [$(DisplayIntWithDots $mergedStatus.Count)] forks" -logToSummary $true
+              SaveStatus -existingForks $mergedStatus
+          } else {
+              Write-Message -message "No updated status.json found from processing job" -logToSummary $true
+          }
+
+          Write-Message -message "" -logToSummary $true
+          Write-Message -message "✓ Consolidation complete" -logToSummary $true
+
+      - name: Setup Node.js for API updates
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@devops-actions'
+
+      - name: Install npm package for API updates
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.DEVOPS_ACTIONS_PACKAGE_DOWNLOAD }}
+        run: |
+          npm install @devops-actions/actions-marketplace-client
+
+      - name: Update API storage with consolidated data
+        if: always()
+        shell: pwsh
+        env:
+          AZ_FUNCTION_URL: ${{ vars.AZ_FUNCTION_URL }}
+          AZ_FUNCTION_TOKEN: ${{ secrets.AZ_FUNCTION_TOKEN }}
+        run: |
+          . ./.github/workflows/library.ps1
+
+          Write-Message -message "" -logToSummary $true
+          Write-Message -message "## API Storage Update" -logToSummary $true
+          Write-Message -message "" -logToSummary $true
+
+          if ([string]::IsNullOrWhiteSpace($env:AZ_FUNCTION_URL) -or [string]::IsNullOrWhiteSpace($env:AZ_FUNCTION_TOKEN)) {
+            Write-Message -message "⚠️ API credentials not available - skipping API update" -logToSummary $true
+            exit 0
+          }
+
+          try {
+            $jsonContent = Get-Content status.json -Raw
+            $jsonContent = $jsonContent -replace '^\uFEFF', ''
+            $status = $jsonContent | ConvertFrom-Json
+          } catch {
+            Write-Message -message "❌ Failed to load status.json: $($_.Exception.Message)" -logToSummary $true
+            exit 0
+          }
+
+          # A single backfill run can update far more than the usual 100
+          # records per hourly run, so push a much larger batch here to avoid
+          # newly-found descriptions sitting unpublished for days behind the
+          # other workflows' smaller per-run caps.
+          $numberOfRepos = 10000
+          Write-Host "Uploading up to $numberOfRepos actions to API storage..."
+          $result = Invoke-ApiUpsert -status $status -apiUrl $env:AZ_FUNCTION_URL -functionKey $env:AZ_FUNCTION_TOKEN -numberOfRepos $numberOfRepos
+
+          if ($result.error) {
+            Write-Message -message "⚠️ API update encountered an error: $($result.error)" -logToSummary $true
+          } else {
+            $totalUpdates = $result.createdCount + $result.updatedCount
+            Write-Message -message "| Status | Count |" -logToSummary $true
+            Write-Message -message "|--------|------:|" -logToSummary $true
+            Write-Message -message "| ✅ Successful | $($result.successCount) |" -logToSummary $true
+            Write-Message -message "| ❌ Failed | $($result.failCount) |" -logToSummary $true
+            Write-Message -message "| 🆕 Created | $($result.createdCount) |" -logToSummary $true
+            Write-Message -message "| 📝 Updated | $($result.updatedCount) |" -logToSummary $true
+            Write-Message -message "| ⏭️ Skipped | $($result.skippedCount) |" -logToSummary $true
+            Write-Message -message "" -logToSummary $true
+            Write-Message -message "✓ Total updates to API: **$totalUpdates** (created + updated)" -logToSummary $true
+          }
+
+          Write-Message -message "" -logToSummary $true
+
+      - name: Upload status.json to blob storage
+        if: always()
+        shell: pwsh
+        env:
+          BLOB_SAS_TOKEN: "${{ secrets.BLOB_SAS_TOKEN }}"
+        run: |
+          . ./.github/workflows/library.ps1
+          $result = Set-StatusToBlobStorage -sasToken $env:BLOB_SAS_TOKEN
+          if (-not $result) {
+            Write-Error "Failed to upload status.json to blob storage"
+            exit 1
+          }

--- a/.github/workflows/description-backfill.yml
+++ b/.github/workflows/description-backfill.yml
@@ -110,12 +110,19 @@ jobs:
           path: updated-data/
 
       - name: Merge changes from processing job
+        id: merge
         shell: pwsh
         run: |
           . ./.github/workflows/library.ps1
 
           Write-Message -message "# Consolidating Description Backfill Changes" -logToSummary $true
           Write-Message -message "" -logToSummary $true
+
+          # Tracks whether we actually merged any updated forks - stays $false
+          # when the processing job produced no output (e.g. it failed before
+          # writing any descriptions), so the API upload step can skip itself
+          # instead of always spending an upload call for nothing.
+          $hasChanges = $false
 
           # Load current status from blob storage
           try {
@@ -180,14 +187,19 @@ jobs:
               $mergedStatus = $statusByName.Values
               Write-Message -message "Saving merged status with [$(DisplayIntWithDots $mergedStatus.Count)] forks" -logToSummary $true
               SaveStatus -existingForks $mergedStatus
+
+              $hasChanges = $mergeCount -gt 0
           } else {
-              Write-Message -message "No updated status.json found from processing job" -logToSummary $true
+              Write-Message -message "No updated status.json found from processing job - nothing to merge (the processing job likely failed before producing output)" -logToSummary $true
           }
 
           Write-Message -message "" -logToSummary $true
           Write-Message -message "✓ Consolidation complete" -logToSummary $true
 
+          "has-changes=$($hasChanges.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Setup Node.js for API updates
+        if: steps.merge.outputs.has-changes == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '20'
@@ -195,13 +207,14 @@ jobs:
           scope: '@devops-actions'
 
       - name: Install npm package for API updates
+        if: steps.merge.outputs.has-changes == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.DEVOPS_ACTIONS_PACKAGE_DOWNLOAD }}
         run: |
           npm install @devops-actions/actions-marketplace-client
 
       - name: Update API storage with consolidated data
-        if: always()
+        if: always() && steps.merge.outputs.has-changes == 'true'
         shell: pwsh
         env:
           AZ_FUNCTION_URL: ${{ vars.AZ_FUNCTION_URL }}

--- a/.github/workflows/functions-chunk.ps1
+++ b/.github/workflows/functions-chunk.ps1
@@ -18,11 +18,11 @@ Param (
 . $PSScriptRoot/library.ps1
 
 if (-not $appIds -or $appIds.Count -eq 0) {
-    $appIds = @($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $appIds = @(@($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
 if (-not $appPrivateKeys -or $appPrivateKeys.Count -eq 0) {
-    $appPrivateKeys = @($env:APPLICATION_PRIVATE_KEY, $env:APPLICATION_PRIVATE_KEY_2, $env:APPLICATION_PRIVATE_KEY_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $appPrivateKeys = @(@($env:APPLICATION_PRIVATE_KEY, $env:APPLICATION_PRIVATE_KEY_2, $env:APPLICATION_PRIVATE_KEY_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
 if ([string]::IsNullOrWhiteSpace($appOrganization)) {

--- a/.github/workflows/github-app-token-manager.ps1
+++ b/.github/workflows/github-app-token-manager.ps1
@@ -120,8 +120,8 @@ function New-GitHubAppTokenManager {
 }
 
 function New-GitHubAppTokenManagerFromEnvironment {
-    $envAppIds = @($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    $envAppPrivateKeys = @($env:APPLICATION_PRIVATE_KEY, $env:APPLICATION_PRIVATE_KEY_2, $env:APPLICATION_PRIVATE_KEY_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $envAppIds = @(@($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $envAppPrivateKeys = @(@($env:APPLICATION_PRIVATE_KEY, $env:APPLICATION_PRIVATE_KEY_2, $env:APPLICATION_PRIVATE_KEY_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
     if ($envAppIds.Count -eq 0 -or $envAppPrivateKeys.Count -eq 0) {
         throw "At least one APP_ID and APPLICATION_PRIVATE_KEY must be provided in environment to create GitHubAppTokenManager"

--- a/.github/workflows/library.ps1
+++ b/.github/workflows/library.ps1
@@ -2357,8 +2357,8 @@ function Get-GitHubAppRateLimitOverview {
     $secondaryKey = $env:APPLICATION_PRIVATE_KEY_2
     $tertiaryKey = $env:APPLICATION_PRIVATE_KEY_3
 
-    $appIds = @($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    $appPrivateKeys = @($primaryKey, $secondaryKey, $tertiaryKey) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $appIds = @(@($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $appPrivateKeys = @(@($primaryKey, $secondaryKey, $tertiaryKey) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
     if ($appIds.Count -eq 0 -or $appPrivateKeys.Count -eq 0) {
         return @()
@@ -2730,8 +2730,8 @@ function Invoke-GitHubAppRateLimitCheckForConfiguredApps {
         throw "APP_ORGANIZATION (or explicit organization parameter) must be provided to perform the rate limit check"
     }
 
-    $appIds = @($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    $appPrivateKeys = @($primaryKey, $secondaryKey, $tertiaryKey) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $appIds = @(@($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $appPrivateKeys = @(@($primaryKey, $secondaryKey, $tertiaryKey) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
     if ($appIds.Count -eq 0 -or $appPrivateKeys.Count -eq 0) {
         throw "At least one APP_ID and APPLICATION_PRIVATE_KEY must be provided to perform the rate limit check"

--- a/.github/workflows/repoInfo-chunk.ps1
+++ b/.github/workflows/repoInfo-chunk.ps1
@@ -17,11 +17,11 @@ Param (
 )
 
 if (-not $appIds -or $appIds.Count -eq 0) {
-    $appIds = @($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $appIds = @(@($env:APP_ID, $env:APP_ID_2, $env:APP_ID_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
 if (-not $appPrivateKeys -or $appPrivateKeys.Count -eq 0) {
-    $appPrivateKeys = @($env:APPLICATION_PRIVATE_KEY, $env:APPLICATION_PRIVATE_KEY_2, $env:APPLICATION_PRIVATE_KEY_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $appPrivateKeys = @(@($env:APPLICATION_PRIVATE_KEY, $env:APPLICATION_PRIVATE_KEY_2, $env:APPLICATION_PRIVATE_KEY_3) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
 if ([string]::IsNullOrWhiteSpace($appOrganization)) {


### PR DESCRIPTION
## Why

Only ~25 of 35,345 records (0.07%) have a populated `description` after 2 days, even though the extraction logic (#244) is live and working. Root cause: description backfill runs inside `repoInfo.ps1`'s regular `GetInfo` loop, which shares its 3 GitHub Apps and per-run update budget with 3 other hourly workflows (`analyze`, `releaseInfo-refresh`, `update-mirrors`). By the time `repoInfo.yml` runs, the shared rate limit is often already exhausted — one observed run spent its entire time budget cycling through rate-limited apps with zero `Checking action information for` log lines.

## What this PR does

Adds a new, lean, self-contained workflow that only backfills `description`, isolated from the contention above:

- **`description-backfill.yml`** — new workflow, runs on its own dedicated 4th GitHub App (`APPLICATION_ID_4` / `AUTOMATION_APP_KEY4`, same `actions-marketplace-validations` org) so it never competes for rate limit with the other 4 hourly workflows. Scheduled every 6 hours (`15 */6 * * *`), plus `workflow_dispatch`. Own concurrency group. `timeout-minutes: 355` as a hard backstop.
- **`description-backfill.ps1`** — targets only records missing `description` that already have a known `actionType.fileFound` of `action.yml`/`action.yaml` from a prior `repoInfo.ps1` run (skips repos with no manifest or only a `Dockerfile`). This means **2 API calls per repo** (contents metadata + raw download) instead of the 4-6+ `GetActionType` needs when probing multiple candidate paths from scratch. Time-budget bound (~340 min internal guard) rather than repo-count bound, so it can use as much of a long-running job as the rate limit allows, with periodic `SaveStatus` checkpoints so a crash doesn't lose already-paid-for API calls.
- Reuses `library.ps1`'s existing `ApiCall` (rate-limit-aware waiting/backoff) and `GetOrgActionInfo`/`SaveStatus`/`Write-Message` helpers — no changes to shared library code.
- The consolidation job pushes up to 10,000 updates per run to the API (vs. the usual 100/run cap) so a large backfill run's results don't sit unpublished for days.

## Manual setup (already done)

- `APPLICATION_ID_4` repo variable set to the new GitHub App's ID.
- `AUTOMATION_APP_KEY4` secret placeholder created — **needs the real private key value set manually** (already communicated separately).
- New GitHub App still needs to be created/installed on `actions-marketplace-validations` with `contents: read` permission on the target repos.

## Not changed

- `repoInfo.ps1`/`repoInfo.yml` and the other 3 hourly workflows are untouched — this is purely additive.
