### PR TITLE
Batch repo metadata refresh through GraphQL to reduce REST volume

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -238,6 +238,7 @@ jobs:
         run: |
           . ./.github/workflows/library.ps1
           Install-ModuleWithRetry -ModuleName "powershell-yaml"
+          Install-ModuleWithRetry -ModuleName "PSGraphQL"
 
       - name: Process repo info chunk ${{ matrix.chunk-id }}
         shell: pwsh

--- a/.github/workflows/library.ps1
+++ b/.github/workflows/library.ps1
@@ -1991,6 +1991,167 @@ function GetRepoReleases {
     return $response
 }
 
+function Invoke-GraphQLRepoMetadataBatch {
+    <#
+    .SYNOPSIS
+        Fetches metadata for a batch of repositories in a single GraphQL query.
+
+    .DESCRIPTION
+        Uses GraphQL aliases to fetch basic metadata (archived/disabled/pushedAt/updatedAt/
+        diskUsage/stargazerCount/defaultBranchRef), fundingLinks, latestRelease and a page of
+        recent tag refs for up to ~50-100 repos in a single request. GraphQL has its own
+        rate-limit pool (points based, separate from REST), so this is used to offload work
+        that would otherwise cost one REST call per repo per field.
+
+        Missing or renamed repos come back with a null repository for their alias and a
+        matching entry in the top-level `errors` array (`path[0]` equal to the alias). Those
+        are surfaced as `NotFound = $true` on the result entry so callers can apply the same
+        handling as a REST 404, without treating the whole batch as failed.
+
+    .PARAMETER RepoPairs
+        Array of objects/hashtables with Owner, Repo and Name properties. Name is the
+        status.json fork name used as the lookup key in the returned Results hashtable.
+
+    .PARAMETER accessToken
+        GitHub token (App installation token) used for the request.
+
+    .PARAMETER tagLimit
+        Number of most-recent tag refs to request per repo. GraphQL's refs connection has no
+        commit-date ordering, so this returns the last N tags in alphabetical order - a
+        best-effort recency signal, not a guaranteed "most recently created" list.
+
+    .OUTPUTS
+        Hashtable with:
+        - Results: hashtable keyed by Name, each value @{ Owner; Repo; Name; Data; NotFound; Errors }
+        - RateLimit: @{ cost; remaining; resetAt; limit } from the query's rateLimit field, or $null
+        - Failed: $true if the whole request failed (network/auth error), in which case callers
+          should fall back to REST for every repo in the batch
+    #>
+    Param (
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyCollection()]
+        [array] $RepoPairs,
+        [Alias('access_token')]
+        $accessToken = $env:GITHUB_TOKEN,
+        [int] $tagLimit = 5
+    )
+
+    $emptyResult = @{ Results = @{}; RateLimit = $null; Failed = $false }
+    if ($null -eq $RepoPairs -or $RepoPairs.Count -eq 0) {
+        return $emptyResult
+    }
+
+    $aliasMap = @{}
+    $variableDefs = @()
+    $queryParts = @()
+    $variables = @{}
+
+    $i = 0
+    foreach ($pair in $RepoPairs) {
+        if ([string]::IsNullOrWhiteSpace($pair.Owner) -or [string]::IsNullOrWhiteSpace($pair.Repo)) {
+            $i++
+            continue
+        }
+
+        $alias = "r$i"
+        $ownerVar = "owner$i"
+        $nameVar = "name$i"
+        $aliasMap[$alias] = $pair
+
+        $variableDefs += ('${0}: String!, ${1}: String!' -f $ownerVar, $nameVar)
+        $variables[$ownerVar] = $pair.Owner
+        $variables[$nameVar] = $pair.Repo
+
+        $queryParts += (@'
+  {0}: repository(owner: ${1}, name: ${2}) {{
+    isArchived
+    isDisabled
+    pushedAt
+    updatedAt
+    diskUsage
+    stargazerCount
+    defaultBranchRef {{ name target {{ oid }} }}
+    fundingLinks {{ platform url }}
+    latestRelease {{ tagName publishedAt }}
+    refs(refPrefix: "refs/tags/", last: {3}) {{
+      nodes {{ name target {{ oid }} }}
+    }}
+  }}
+'@ -f $alias, $ownerVar, $nameVar, $tagLimit)
+
+        $i++
+    }
+
+    if ($aliasMap.Count -eq 0) {
+        return $emptyResult
+    }
+
+    $query = "query(" + ($variableDefs -join ", ") + ") {`n" + ($queryParts -join "`n") + "`n  rateLimit { cost remaining resetAt limit }`n}"
+    $variablesJson = $variables | ConvertTo-Json -Compress
+
+    $uri = "https://api.github.com/graphql"
+    $requestHeaders = @{
+        Authorization = GetBasicAuthenticationHeader -access_token $accessToken
+    }
+
+    try {
+        $response = (Invoke-GraphQLQuery -Query $query -Variables $variablesJson -Uri $uri -Headers $requestHeaders -Raw | ConvertFrom-Json)
+    }
+    catch {
+        Write-Host "GraphQL batch request failed for [$($aliasMap.Count)] repos: $($_.Exception.Message)"
+        return @{ Results = @{}; RateLimit = $null; Failed = $true }
+    }
+
+    $rateLimitInfo = $null
+    if ($null -ne $response.data -and $null -ne $response.data.rateLimit) {
+        $rateLimitInfo = @{
+            cost = $response.data.rateLimit.cost
+            remaining = $response.data.rateLimit.remaining
+            resetAt = $response.data.rateLimit.resetAt
+            limit = $response.data.rateLimit.limit
+        }
+
+        if ($rateLimitInfo.remaining -lt 500) {
+            Write-Warning "GraphQL rate limit is low: [$($rateLimitInfo.remaining)] points remaining, resets at [$($rateLimitInfo.resetAt)]"
+        }
+    }
+
+    # Map per-alias errors (missing/renamed repos come back as data.<alias> = null with a
+    # matching entry in the top-level errors array whose path[0] is the alias)
+    $errorsByAlias = @{}
+    if ($null -ne $response.errors) {
+        foreach ($err in $response.errors) {
+            if ($null -ne $err.path -and $err.path.Count -gt 0) {
+                $errAlias = "$($err.path[0])"
+                if (-not $errorsByAlias.ContainsKey($errAlias)) {
+                    $errorsByAlias[$errAlias] = @()
+                }
+                $errorsByAlias[$errAlias] += $err
+            }
+        }
+    }
+
+    $results = @{}
+    foreach ($alias in $aliasMap.Keys) {
+        $pair = $aliasMap[$alias]
+        $repoData = $null
+        if ($null -ne $response.data) {
+            $repoData = $response.data.$alias
+        }
+
+        $results[$pair.Name] = @{
+            Owner = $pair.Owner
+            Repo = $pair.Repo
+            Name = $pair.Name
+            Data = $repoData
+            NotFound = ($null -eq $repoData)
+            Errors = if ($errorsByAlias.ContainsKey($alias)) { $errorsByAlias[$alias] } else { @() }
+        }
+    }
+
+    return @{ Results = $results; RateLimit = $rateLimitInfo; Failed = $false }
+}
+
 function SplitUrlLastPart {
     Param (
         $url

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -1532,6 +1532,91 @@ function GetMoreInfo {
     $originalRepoDoesNotExists = New-Object System.Collections.ArrayList
     # store the timestamp
     $startTime = Get-Date
+
+    # --- GraphQL batch pre-fetch for plain repoInfo metadata refresh ---
+    # Batches repos whose repoInfo is missing/stale through the GraphQL API (a separate
+    # rate-limit pool from REST) instead of one REST call per repo via GetRepoInfo. The main
+    # loop below falls back to the existing per-repo REST path for anything not covered here
+    # (GraphQL request failure for a whole batch, or repos with no parseable owner/repo).
+    $graphqlResultsByName = @{}
+    $graphqlStats = @{
+        BatchCount = 0
+        ReposRequested = 0
+        ReposRefreshed = 0
+        ReposNotFound = 0
+        TotalCost = 0
+        RestCallsAvoided = 0
+    }
+
+    $graphqlCandidates = @()
+    foreach ($action in $forksToProcess) {
+        if (!$action.upstreamFound) {
+            continue
+        }
+
+        $hasRepoInfoFieldForBatch = Get-Member -inputobject $action -name "repoInfo" -Membertype Properties
+        $repoInfoIsStaleForBatch = $false
+        if ($hasRepoInfoFieldForBatch -and $action.repoInfo) {
+            $hasLastFetchedForBatch = Get-Member -inputobject $action.repoInfo -name "lastFetched" -Membertype Properties
+            if (!$hasLastFetchedForBatch -or ($null -eq $action.repoInfo.lastFetched)) {
+                $repoInfoIsStaleForBatch = $true
+            }
+            else {
+                try {
+                    $daysSinceLastFetchForBatch = ((Get-Date) - [datetime]$action.repoInfo.lastFetched).TotalDays
+                    if ($daysSinceLastFetchForBatch -gt 14) { $repoInfoIsStaleForBatch = $true }
+                }
+                catch { $repoInfoIsStaleForBatch = $true }
+            }
+        }
+
+        $needsGraphQLRefresh = !$hasRepoInfoFieldForBatch -or ($hasRepoInfoFieldForBatch -and ($null -eq $action.repoInfo.updated_at)) -or $repoInfoIsStaleForBatch
+        if ($needsGraphQLRefresh) {
+            ($ownerForBatch, $repoForBatch) = GetOrgActionInfo($action.name)
+            if ($ownerForBatch -ne "" -and $repoForBatch -ne "") {
+                $graphqlCandidates += @{ Owner = $ownerForBatch; Repo = $repoForBatch; Name = $action.name }
+            }
+        }
+    }
+
+    if ($graphqlCandidates.Count -gt 0) {
+        Write-Host "Batching [$($graphqlCandidates.Count)] repos with missing/stale repoInfo through GraphQL"
+        $graphqlBatchSize = 50
+        for ($batchStart = 0; $batchStart -lt $graphqlCandidates.Count; $batchStart += $graphqlBatchSize) {
+            $batchEnd = [Math]::Min($batchStart + $graphqlBatchSize, $graphqlCandidates.Count) - 1
+            $batch = $graphqlCandidates[$batchStart..$batchEnd]
+
+            $batchResult = Invoke-GraphQLRepoMetadataBatch -RepoPairs $batch -accessToken $accessToken
+            $graphqlStats.BatchCount++
+            $graphqlStats.ReposRequested += $batch.Count
+
+            if ($batchResult.Failed) {
+                Write-Host "GraphQL batch [$($graphqlStats.BatchCount)] failed; those [$($batch.Count)] repos will fall back to REST"
+                continue
+            }
+
+            if ($null -ne $batchResult.RateLimit) {
+                Write-Host "GraphQL batch [$($graphqlStats.BatchCount)]: cost [$($batchResult.RateLimit.cost)] point(s), [$($batchResult.RateLimit.remaining)] remaining"
+                $graphqlStats.TotalCost += $batchResult.RateLimit.cost
+            }
+
+            foreach ($name in $batchResult.Results.Keys) {
+                $graphqlResultsByName[$name] = $batchResult.Results[$name]
+                if ($batchResult.Results[$name].NotFound) {
+                    $graphqlStats.ReposNotFound++
+                }
+                else {
+                    $graphqlStats.ReposRefreshed++
+                }
+            }
+        }
+
+        # Each repo refreshed via GraphQL replaces 2 REST calls that GetRepoInfo would have
+        # made (repo info + latest release).
+        $graphqlStats.RestCallsAvoided = $graphqlStats.ReposRefreshed * 2
+    }
+    # --- end GraphQL batch pre-fetch ---
+
     try {
         foreach ($action in $forksToProcess) {
             $script:moreInfoMetrics.TotalReposExamined++
@@ -1583,10 +1668,20 @@ function GetMoreInfo {
             }
             
             if (!$hasField -or ($null -eq $action.actionType.actionType) -or ($hasField -and ($null -eq $action.repoInfo.updated_at)) -or $repoInfoStale) {
-                Write-Host "$i/$max - Checking extended action information for [$forkOrg/$($action.name)]. hasField: [$($null -ne $hasField)], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
-                try {
-                    ($repo_archived, $repo_disabled, $repo_updated_at, $latest_release_published_at, $statusCode) = GetRepoInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
-                    if ($statusCode -and ($statusCode -eq "NotFound")) {
+                $repo_archived = $null
+                $repo_disabled = $null
+                $repo_updated_at = $null
+                $latest_release_published_at = $null
+
+                $graphqlEntry = $null
+                if ($graphqlResultsByName.ContainsKey($action.name)) {
+                    $graphqlEntry = $graphqlResultsByName[$action.name]
+                }
+
+                if ($null -ne $graphqlEntry) {
+                    Write-Host "$i/$max - Checking extended action information for [$forkOrg/$($action.name)] via GraphQL batch"
+
+                    if ($graphqlEntry.NotFound) {
                         $action.upstreamFound = $false
                         # todo: remove this repo from the list (and push it back into the original actions list!)
                         $actionNoLongerExists = @{
@@ -1598,68 +1693,93 @@ function GetMoreInfo {
                         continue
                     }
 
-                    if ($repo_updated_at) {
-                        if (!$hasField) {
-                            Write-Host "Adding repo information object with archived:[$($repo_archived)], disabled:[$($repo_disabled)], updated_at:[$($repo_updated_at)], latest_release_published_at:[$($latest_release_published_at)] for [$($action.owner)/$($action.name)]"
-                            $repoInfo = @{
-                                archived = $repo_archived
-                                disabled = $repo_disabled
-                                updated_at = $repo_updated_at
-                                latest_release_published_at = $latest_release_published_at
-                                lastFetched = (Get-Date -Format 'o')
-                            }
-
-                            $action | Add-Member -Name repoInfo -Value $repoInfo -MemberType NoteProperty
-                            $memberAdded++ | Out-Null
-                            $i++ | Out-Null
-                        }
-                        else {
-                            Write-Host "Updating repo information object with archived:[$($repo_archived)], disabled:[$($repo_disabled)], updated_at:[$($repo_updated_at)], latest_release_published_at:[$($latest_release_published_at)]"
-                            $action.repoInfo.archived = $repo_archived
-                            $action.repoInfo.disabled = $repo_disabled
-                            $action.repoInfo.updated_at = $repo_updated_at
-                            $action.repoInfo.latest_release_published_at = $latest_release_published_at
-                            $action.repoInfo | Add-Member -Name lastFetched -Value (Get-Date -Format 'o') -MemberType NoteProperty -Force
-                            $memberUpdate++ | Out-Null
-                        }
+                    $repoData = $graphqlEntry.Data
+                    $repo_archived = $repoData.isArchived
+                    $repo_disabled = $repoData.isDisabled
+                    $repo_updated_at = $repoData.updatedAt
+                    if ($repoData.latestRelease) {
+                        $latest_release_published_at = $repoData.latestRelease.publishedAt
                     }
                 }
-                catch {
-                    $errorMsg = $_.Exception.Message
-                    Write-Host "Error calling GetRepoInfo for [$owner/$repo]: $errorMsg"
-                    
-                    # Track upstream repo 404 errors
-                    if (Is404Error -errorMessage $errorMsg) {
-                        $script:errorCounts.UpstreamRepo404++
-                        $script:errorDetails.UpstreamRepo404 += "$owner/$repo"
-                    }
-                    else {
-                        $script:errorCounts.OtherErrors++
-                        $script:errorDetails.OtherErrors += "$owner/$repo : $errorMsg"
-                    }
-                    
-                    # Check if our forked copy exists
+                else {
+                    Write-Host "$i/$max - Checking extended action information for [$forkOrg/$($action.name)] via REST fallback. hasField: [$($null -ne $hasField)], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
                     try {
-                        $forkCheckUrl = "/repos/$forkOrg/$($action.name)"
-                        $forkResponse = ApiCall -method GET -url $forkCheckUrl -hideFailedCall $true -access_token $accessToken
-                        if ($null -ne $forkResponse -and $forkResponse.id -gt 0) {
-                            Write-Host "Our forked copy exists at [$forkOrg/$($action.name)] (id: $($forkResponse.id)), but upstream repo [$owner/$repo] may not exist or is inaccessible"
-                        }
-                        else {
-                            Write-Host "Fork check returned unexpected response for [$forkOrg/$($action.name)]"
+                        ($repo_archived, $repo_disabled, $repo_updated_at, $latest_release_published_at, $statusCode) = GetRepoInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
+                        if ($statusCode -and ($statusCode -eq "NotFound")) {
+                            $action.upstreamFound = $false
+                            # todo: remove this repo from the list (and push it back into the original actions list!)
+                            $actionNoLongerExists = @{
+                                action = $($action.name)
+                                owner = $owner
+                                repo = $repo
+                            }
+                            $originalRepoDoesNotExists.Add($actionNoLongerExists) | Out-Null
+                            continue
                         }
                     }
                     catch {
-                        $forkErrorMsg = $_.Exception.Message
-                        Write-Host "Our forked copy does not exist at [$forkOrg/$($action.name)]: $forkErrorMsg"
-                        
-                        # Track fork 404 errors
-                        if (Is404Error -errorMessage $forkErrorMsg) {
-                            $script:errorCounts.ForkRepo404++
-                            $script:errorDetails.ForkRepo404 += "$forkOrg/$($action.name)"
+                        $errorMsg = $_.Exception.Message
+                        Write-Host "Error calling GetRepoInfo for [$owner/$repo]: $errorMsg"
+
+                        # Track upstream repo 404 errors
+                        if (Is404Error -errorMessage $errorMsg) {
+                            $script:errorCounts.UpstreamRepo404++
+                            $script:errorDetails.UpstreamRepo404 += "$owner/$repo"
                         }
+                        else {
+                            $script:errorCounts.OtherErrors++
+                            $script:errorDetails.OtherErrors += "$owner/$repo : $errorMsg"
+                        }
+
+                        # Check if our forked copy exists
+                        try {
+                            $forkCheckUrl = "/repos/$forkOrg/$($action.name)"
+                            $forkResponse = ApiCall -method GET -url $forkCheckUrl -hideFailedCall $true -access_token $accessToken
+                            if ($null -ne $forkResponse -and $forkResponse.id -gt 0) {
+                                Write-Host "Our forked copy exists at [$forkOrg/$($action.name)] (id: $($forkResponse.id)), but upstream repo [$owner/$repo] may not exist or is inaccessible"
+                            }
+                            else {
+                                Write-Host "Fork check returned unexpected response for [$forkOrg/$($action.name)]"
+                            }
+                        }
+                        catch {
+                            $forkErrorMsg = $_.Exception.Message
+                            Write-Host "Our forked copy does not exist at [$forkOrg/$($action.name)]: $forkErrorMsg"
+
+                            # Track fork 404 errors
+                            if (Is404Error -errorMessage $forkErrorMsg) {
+                                $script:errorCounts.ForkRepo404++
+                                $script:errorDetails.ForkRepo404 += "$forkOrg/$($action.name)"
+                            }
+                        }
+                        # continue with next one, repo_updated_at stays $null so the block below is skipped
                     }
-                    # continue with next one
+                }
+
+                if ($repo_updated_at) {
+                    if (!$hasField) {
+                        Write-Host "Adding repo information object with archived:[$($repo_archived)], disabled:[$($repo_disabled)], updated_at:[$($repo_updated_at)], latest_release_published_at:[$($latest_release_published_at)] for [$($action.owner)/$($action.name)]"
+                        $repoInfo = @{
+                            archived = $repo_archived
+                            disabled = $repo_disabled
+                            updated_at = $repo_updated_at
+                            latest_release_published_at = $latest_release_published_at
+                            lastFetched = (Get-Date -Format 'o')
+                        }
+
+                        $action | Add-Member -Name repoInfo -Value $repoInfo -MemberType NoteProperty
+                        $memberAdded++ | Out-Null
+                        $i++ | Out-Null
+                    }
+                    else {
+                        Write-Host "Updating repo information object with archived:[$($repo_archived)], disabled:[$($repo_disabled)], updated_at:[$($repo_updated_at)], latest_release_published_at:[$($latest_release_published_at)]"
+                        $action.repoInfo.archived = $repo_archived
+                        $action.repoInfo.disabled = $repo_disabled
+                        $action.repoInfo.updated_at = $repo_updated_at
+                        $action.repoInfo.latest_release_published_at = $latest_release_published_at
+                        $action.repoInfo | Add-Member -Name lastFetched -Value (Get-Date -Format 'o') -MemberType NoteProperty -Force
+                        $memberUpdate++ | Out-Null
+                    }
                 }
             }
 
@@ -1938,6 +2058,27 @@ function GetMoreInfo {
     if ($dockerBaseImageInfoAdded -gt 0) {
         $summaryOutput += "`nDocker base image information added for [$(DisplayIntWithDots $dockerBaseImageInfoAdded)] actions"
     }
+
+    # GraphQL batch stats: repos refreshed per GraphQL point spent vs the REST-call
+    # equivalent that would have been made through GetRepoInfo (1 call for repo info +
+    # 1 call for latest release, per repo).
+    if ($graphqlStats.ReposRequested -gt 0) {
+        $graphqlSummary = "`n`n## GraphQL Batch Metadata Refresh`n`n"
+        $graphqlSummary += "| Metric | Count |`n"
+        $graphqlSummary += "| --- | --- |`n"
+        $graphqlSummary += "| Batch queries executed | $(DisplayIntWithDots $graphqlStats.BatchCount) |`n"
+        $graphqlSummary += "| Repos requested | $(DisplayIntWithDots $graphqlStats.ReposRequested) |`n"
+        $graphqlSummary += "| Repos refreshed | $(DisplayIntWithDots $graphqlStats.ReposRefreshed) |`n"
+        $graphqlSummary += "| Repos not found (deleted/renamed) | $(DisplayIntWithDots $graphqlStats.ReposNotFound) |`n"
+        $graphqlSummary += "| GraphQL points spent | $(DisplayIntWithDots $graphqlStats.TotalCost) |`n"
+        $graphqlSummary += "| Equivalent REST calls avoided | $(DisplayIntWithDots $graphqlStats.RestCallsAvoided) |`n"
+        if ($graphqlStats.TotalCost -gt 0) {
+            $reposPerPoint = [math]::Round($graphqlStats.ReposRefreshed / $graphqlStats.TotalCost, 2)
+            $graphqlSummary += "| Repos refreshed per GraphQL point | $reposPerPoint |`n"
+        }
+        $summaryOutput += $graphqlSummary
+    }
+
     Write-Message -message $summaryOutput -logToSummary $true
 
     Write-Host "Starting the cleanup with [$($existingForks.Count)] actions and [$($originalRepoDoesNotExists.Count)] original repos that do not exist"

--- a/tests/graphqlRepoMetadataBatch.Tests.ps1
+++ b/tests/graphqlRepoMetadataBatch.Tests.ps1
@@ -1,0 +1,159 @@
+BeforeAll {
+    # PSGraphQL isn't installed in the test environment; define a stub so Pester has a
+    # real command to intercept with Mock (the workflow installs the real module before
+    # any of this code runs - see Install-ModuleWithRetry -ModuleName "PSGraphQL").
+    function Invoke-GraphQLQuery {
+        Param ($Query, $Variables, $Uri, $Headers, [switch] $Raw)
+    }
+
+    . $PSScriptRoot/../.github/workflows/library.ps1
+}
+
+Describe "Invoke-GraphQLRepoMetadataBatch" {
+    Context "Empty input" {
+        It "Returns an empty result without calling GraphQL" {
+            Mock -CommandName Invoke-GraphQLQuery -MockWith { throw "should not be called" }
+
+            $result = Invoke-GraphQLRepoMetadataBatch -RepoPairs @() -accessToken "token"
+
+            $result.Results.Count | Should -Be 0
+            $result.RateLimit | Should -BeNullOrEmpty
+            $result.Failed | Should -Be $false
+            Should -Invoke -CommandName Invoke-GraphQLQuery -Times 0
+        }
+    }
+
+    Context "Successful batch with a partial per-alias error" {
+        BeforeEach {
+            # Mock + the call under test both live in BeforeEach (not BeforeAll) so each
+            # It block gets its own tracked Invoke-GraphQLQuery call count - Pester resets
+            # mock call history per test, so a call made once in a Context-level BeforeAll
+            # would not be visible to "Should -Invoke" inside individual It blocks.
+            $script:mockResponse = @{
+                data = @{
+                    r0 = @{
+                        isArchived = $false
+                        isDisabled = $false
+                        pushedAt = "2024-01-01T00:00:00Z"
+                        updatedAt = "2024-01-02T00:00:00Z"
+                        diskUsage = 123
+                        stargazerCount = 5
+                        defaultBranchRef = @{ name = "main"; target = @{ oid = "abc123" } }
+                        fundingLinks = @(@{ platform = "GITHUB"; url = "https://github.com/sponsors/ownerA" })
+                        latestRelease = @{ tagName = "v1.0.0"; publishedAt = "2024-01-01T00:00:00Z" }
+                        refs = @{ nodes = @(@{ name = "v1.0.0"; target = @{ oid = "abc123" } }) }
+                    }
+                    r1 = $null
+                    rateLimit = @{ cost = 2; remaining = 4998; resetAt = "2024-01-01T01:00:00Z"; limit = 5000 }
+                }
+                errors = @(
+                    @{
+                        type = "NOT_FOUND"
+                        path = @("r1")
+                        message = "Could not resolve to a Repository with the name 'repoB'."
+                    }
+                )
+            }
+            $script:mockResponseJson = $script:mockResponse | ConvertTo-Json -Depth 10
+
+            Mock -CommandName Invoke-GraphQLQuery -MockWith { $script:mockResponseJson }
+
+            $script:repoPairs = @(
+                @{ Owner = "ownerA"; Repo = "repoA"; Name = "ownerA_repoA" }
+                @{ Owner = "ownerB"; Repo = "repoB"; Name = "ownerB_repoB" }
+            )
+
+            $script:result = Invoke-GraphQLRepoMetadataBatch -RepoPairs $script:repoPairs -accessToken "token"
+        }
+
+        It "Calls the GraphQL endpoint exactly once for the whole batch" {
+            Should -Invoke -CommandName Invoke-GraphQLQuery -Times 1
+        }
+
+        It "Builds a query with one aliased repository field per repo" {
+            Should -Invoke -CommandName Invoke-GraphQLQuery -ParameterFilter {
+                $Query -match "r0: repository\(owner: \`$owner0, name: \`$name0\)" -and
+                $Query -match "r1: repository\(owner: \`$owner1, name: \`$name1\)" -and
+                $Query -match "rateLimit \{ cost remaining resetAt limit \}"
+            }
+        }
+
+        It "Passes owner/name pairs as GraphQL variables" {
+            Should -Invoke -CommandName Invoke-GraphQLQuery -ParameterFilter {
+                $parsedVars = $Variables | ConvertFrom-Json
+                $parsedVars.owner0 -eq "ownerA" -and $parsedVars.name0 -eq "repoA" -and
+                $parsedVars.owner1 -eq "ownerB" -and $parsedVars.name1 -eq "repoB"
+            }
+        }
+
+        It "Maps the found repo's data by fork name" {
+            $entry = $script:result.Results["ownerA_repoA"]
+            $entry | Should -Not -BeNullOrEmpty
+            $entry.NotFound | Should -Be $false
+            $entry.Data.isArchived | Should -Be $false
+            # ConvertFrom-Json auto-parses ISO-8601-looking strings into [datetime], and a
+            # bare [datetime] cast of a literal "Z" string can land in local Kind - compare
+            # normalized UTC instants rather than exact string/Kind formatting.
+            ([datetime]$entry.Data.updatedAt).ToUniversalTime() | Should -Be ([datetime]"2024-01-02T00:00:00Z").ToUniversalTime()
+            ([datetime]$entry.Data.latestRelease.publishedAt).ToUniversalTime() | Should -Be ([datetime]"2024-01-01T00:00:00Z").ToUniversalTime()
+        }
+
+        It "Marks the missing/renamed repo as NotFound and attaches its error" {
+            $entry = $script:result.Results["ownerB_repoB"]
+            $entry | Should -Not -BeNullOrEmpty
+            $entry.NotFound | Should -Be $true
+            $entry.Data | Should -BeNullOrEmpty
+            $entry.Errors.Count | Should -Be 1
+            $entry.Errors[0].type | Should -Be "NOT_FOUND"
+        }
+
+        It "Does not let one alias's error affect the other alias's result" {
+            $script:result.Results["ownerA_repoA"].NotFound | Should -Be $false
+        }
+
+        It "Surfaces the rateLimit cost/remaining/resetAt from the query" {
+            $script:result.RateLimit.cost | Should -Be 2
+            $script:result.RateLimit.remaining | Should -Be 4998
+            ([datetime]$script:result.RateLimit.resetAt).ToUniversalTime() | Should -Be ([datetime]"2024-01-01T01:00:00Z").ToUniversalTime()
+        }
+
+        It "Does not mark the batch as Failed" {
+            $script:result.Failed | Should -Be $false
+        }
+    }
+
+    Context "Repo pairs with missing owner or repo are skipped" {
+        It "Excludes entries with blank Owner/Repo from the query and results" {
+            $mockResponse = @{
+                data = @{
+                    r0 = @{ isArchived = $false; isDisabled = $false; updatedAt = "2024-01-02T00:00:00Z" }
+                    rateLimit = @{ cost = 1; remaining = 4999; resetAt = "2024-01-01T01:00:00Z"; limit = 5000 }
+                }
+            }
+            $mockResponseJson = $mockResponse | ConvertTo-Json -Depth 10
+            Mock -CommandName Invoke-GraphQLQuery -MockWith { $mockResponseJson }
+
+            $repoPairs = @(
+                @{ Owner = ""; Repo = ""; Name = "invalid_entry" }
+                @{ Owner = "ownerA"; Repo = "repoA"; Name = "ownerA_repoA" }
+            )
+
+            $result = Invoke-GraphQLRepoMetadataBatch -RepoPairs $repoPairs -accessToken "token"
+
+            $result.Results.ContainsKey("invalid_entry") | Should -Be $false
+            $result.Results.ContainsKey("ownerA_repoA") | Should -Be $true
+        }
+    }
+
+    Context "GraphQL request failure" {
+        It "Returns Failed = true and an empty Results hashtable" {
+            Mock -CommandName Invoke-GraphQLQuery -MockWith { throw "network error" }
+
+            $repoPairs = @(@{ Owner = "ownerA"; Repo = "repoA"; Name = "ownerA_repoA" })
+            $result = Invoke-GraphQLRepoMetadataBatch -RepoPairs $repoPairs -accessToken "token"
+
+            $result.Failed | Should -Be $true
+            $result.Results.Count | Should -Be 0
+        }
+    }
+}

--- a/tests/repoInfoGraphQLIntegration.Tests.ps1
+++ b/tests/repoInfoGraphQLIntegration.Tests.ps1
@@ -1,0 +1,149 @@
+BeforeAll {
+    # Duplicates the "apply a GraphQL batch result (or fall back to REST) to an action's
+    # repoInfo" decision from GetMoreInfo in repoInfo.ps1, so it can be tested without
+    # executing the full script (which has top-level params/side effects). Keep this in
+    # sync with the block in repoInfo.ps1 around the repoInfo staleness check.
+    function Resolve-RepoInfoFromGraphQLOrRest {
+        Param (
+            $action,
+            [hashtable] $graphqlResultsByName,
+            [scriptblock] $restFallback
+        )
+
+        $graphqlEntry = $null
+        if ($graphqlResultsByName.ContainsKey($action.name)) {
+            $graphqlEntry = $graphqlResultsByName[$action.name]
+        }
+
+        if ($null -ne $graphqlEntry) {
+            if ($graphqlEntry.NotFound) {
+                return @{ UpstreamFound = $false; RepoInfo = $null; Source = "GraphQL" }
+            }
+
+            $repoData = $graphqlEntry.Data
+            $latestReleasePublishedAt = $null
+            if ($repoData.latestRelease) {
+                $latestReleasePublishedAt = $repoData.latestRelease.publishedAt
+            }
+
+            return @{
+                UpstreamFound = $true
+                Source = "GraphQL"
+                RepoInfo = @{
+                    archived = $repoData.isArchived
+                    disabled = $repoData.isDisabled
+                    updated_at = $repoData.updatedAt
+                    latest_release_published_at = $latestReleasePublishedAt
+                }
+            }
+        }
+
+        # No GraphQL result for this repo (batch failed, or it wasn't a candidate) - fall
+        # back to REST, exactly like the pre-GraphQL code path did.
+        return (& $restFallback)
+    }
+}
+
+Describe "repoInfo.ps1 GraphQL-first repoInfo refresh" {
+    Context "Repo found in the GraphQL batch" {
+        It "Uses the GraphQL data instead of calling REST" {
+            $restCalled = $false
+            $restFallback = { $restCalled = $true; return @{ UpstreamFound = $true; RepoInfo = @{}; Source = "REST" } }.GetNewClosure()
+
+            $graphqlResults = @{
+                "ownerA_repoA" = @{
+                    NotFound = $false
+                    Data = @{
+                        isArchived = $false
+                        isDisabled = $false
+                        updatedAt = "2024-03-01T00:00:00Z"
+                        latestRelease = @{ tagName = "v2.0.0"; publishedAt = "2024-02-15T00:00:00Z" }
+                    }
+                }
+            }
+
+            $action = [PSCustomObject]@{ name = "ownerA_repoA" }
+            $result = Resolve-RepoInfoFromGraphQLOrRest -action $action -graphqlResultsByName $graphqlResults -restFallback $restFallback
+
+            $result.Source | Should -Be "GraphQL"
+            $result.UpstreamFound | Should -Be $true
+            $result.RepoInfo.updated_at | Should -Be "2024-03-01T00:00:00Z"
+            $result.RepoInfo.latest_release_published_at | Should -Be "2024-02-15T00:00:00Z"
+            $restCalled | Should -Be $false
+        }
+    }
+
+    Context "Repo reported as not found by the GraphQL batch (partial-error case)" {
+        It "Marks upstreamFound = false without falling back to REST" {
+            $restCalled = $false
+            $restFallback = { $restCalled = $true; return @{ UpstreamFound = $true; RepoInfo = @{}; Source = "REST" } }.GetNewClosure()
+
+            $graphqlResults = @{
+                "ownerB_repoB" = @{
+                    NotFound = $true
+                    Data = $null
+                    Errors = @(@{ type = "NOT_FOUND"; path = @("r1") })
+                }
+            }
+
+            $action = [PSCustomObject]@{ name = "ownerB_repoB" }
+            $result = Resolve-RepoInfoFromGraphQLOrRest -action $action -graphqlResultsByName $graphqlResults -restFallback $restFallback
+
+            $result.Source | Should -Be "GraphQL"
+            $result.UpstreamFound | Should -Be $false
+            $result.RepoInfo | Should -BeNullOrEmpty
+            $restCalled | Should -Be $false
+        }
+    }
+
+    Context "Repo missing from the GraphQL batch (batch failed or not a candidate)" {
+        It "Falls back to REST" {
+            # Use a shared ArrayList (mutated in place) rather than reassigning a plain
+            # variable inside the scriptblock - a scriptblock invoked via "&" runs in a new
+            # child scope, so plain variable assignments inside it don't propagate back out.
+            $callLog = New-Object System.Collections.ArrayList
+            $restFallback = { $callLog.Add($true) | Out-Null; return @{ UpstreamFound = $true; RepoInfo = @{ archived = $false }; Source = "REST" } }.GetNewClosure()
+
+            $graphqlResults = @{}
+
+            $action = [PSCustomObject]@{ name = "ownerC_repoC" }
+            $result = Resolve-RepoInfoFromGraphQLOrRest -action $action -graphqlResultsByName $graphqlResults -restFallback $restFallback
+
+            $result.Source | Should -Be "REST"
+            $callLog.Count | Should -Be 1
+        }
+    }
+
+    Context "Mixed batch: one hit, one not-found, one REST fallback" {
+        It "Resolves each action independently from a single shared GraphQL results map" {
+            $graphqlResults = @{
+                "ownerA_repoA" = @{
+                    NotFound = $false
+                    Data = @{ isArchived = $false; isDisabled = $false; updatedAt = "2024-03-01T00:00:00Z" }
+                }
+                "ownerB_repoB" = @{
+                    NotFound = $true
+                    Data = $null
+                }
+            }
+
+            $actions = @(
+                [PSCustomObject]@{ name = "ownerA_repoA" }
+                [PSCustomObject]@{ name = "ownerB_repoB" }
+                [PSCustomObject]@{ name = "ownerC_repoC" }
+            )
+
+            $results = foreach ($action in $actions) {
+                Resolve-RepoInfoFromGraphQLOrRest -action $action -graphqlResultsByName $graphqlResults -restFallback { return @{ UpstreamFound = $true; RepoInfo = @{ archived = $false }; Source = "REST" } }
+            }
+
+            $results[0].Source | Should -Be "GraphQL"
+            $results[0].UpstreamFound | Should -Be $true
+
+            $results[1].Source | Should -Be "GraphQL"
+            $results[1].UpstreamFound | Should -Be $false
+
+            $results[2].Source | Should -Be "REST"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The hourly `repoInfo.ps1` refresh (driven by `repoInfo.yml` / chunked via `repoInfo-chunk.ps1`) checks up to 100 repos/run, and for every repo whose `repoInfo` (archived/disabled/updated_at/latest_release_published_at) is missing or older than 14 days, it made **2 sequential REST calls** via `GetRepoInfo`: `GET /repos/{owner}/{repo}` + `GET /repos/{owner}/{repo}/releases/latest`. That's up to **200 REST calls/hour** (~4,800/day) just for this one refresh, all against the shared REST rate-limit pool that every other step in the pipeline (tag info, release list, funding, actionType parsing, Docker/Trivy scans, secret scanning) also competes for.

GitHub's GraphQL API has its **own separate rate-limit pool** (base 5,000 points/hour per installation, up to 12,500/hour) that this pipeline wasn't using at all. This PR batches the plain-metadata refresh through GraphQL instead, freeing up the REST pool for the calls that still need it.

## What changed

1. **`Invoke-GraphQLRepoMetadataBatch` (`library.ps1`)** — new helper that builds a single aliased GraphQL query (`r0: repository(...)`, `r1: repository(...)`, ...) for a batch of owner/repo pairs, fetching `isArchived`, `isDisabled`, `pushedAt`, `updatedAt`, `diskUsage`, `stargazerCount`, `defaultBranchRef`, `fundingLinks`, `latestRelease`, and a page of recent tag `refs`, plus the query's `rateLimit { cost remaining resetAt limit }`. Uses `Invoke-GraphQLQuery` from PSGraphQL (same module/pattern already used by `GetDependabotVulnerabilityAlerts`). Missing/renamed repos come back as `data.<alias> = null` with a matching entry in the top-level `errors` array (`path[0] == alias`) — these are mapped to `NotFound = $true` per-repo instead of failing the whole batch.

2. **`GetMoreInfo` (`repoInfo.ps1`)** — before its per-repo loop, pre-batches every candidate with stale/missing `repoInfo` through the helper (50 repos/query), then in the loop uses the batched GraphQL data instead of calling `GetRepoInfo` wherever a result is available, falling back to the original REST path only when a repo wasn't covered (batch request failure). `status.json`'s `repoInfo` schema is unchanged — same fields, same shape, so `report.ps1`/`api-upsert.ps1` need no changes.

3. **Workflow summary** — adds a "GraphQL Batch Metadata Refresh" table (batch count, repos requested/refreshed/not-found, GraphQL points spent, equivalent REST calls avoided, repos refreshed per point).

4. **`analyze.yml`** — the chunked path (`repoInfo-chunk.ps1` → `repoInfo.ps1`) now also installs the `PSGraphQL` module, matching what `repoInfo.yml`'s direct path already did.

5. **Tests** (`tests/graphqlRepoMetadataBatch.Tests.ps1`, `tests/repoInfoGraphQLIntegration.Tests.ps1`) — mocked-GraphQL-response coverage for the helper (successful batch, partial per-alias `NOT_FOUND` error, blank owner/repo skipping, whole-request failure) and for the `repoInfo.ps1` integration decision (GraphQL hit, GraphQL not-found, REST fallback, mixed batch).

## Before / after call-volume estimate

At `numberOfReposToDo: 100`, for the subset of repos needing a plain metadata refresh in a given hourly run:

| | REST calls | GraphQL queries | GraphQL points (approx.) |
|---|---:|---:|---:|
| **Before** | up to 200 (2 × 100) | 0 | 0 |
| **After** | 0 (for this refresh path) | 2 (50/batch) | reported live in the step summary; each batch's actual cost comes straight from the query's `rateLimit.cost` field |

Net effect: up to ~200 REST calls/hour move off the REST pool entirely, landing instead on GraphQL's separate budget — REST headroom that other still-REST-only steps in the same run (tag refs, full release list, funding file parsing, actionType/Docker file parsing, Trivy scans, secret scanning) can now use.

## Test plan

- [x] `Invoke-Pester -Path tests/graphqlRepoMetadataBatch.Tests.ps1,tests/repoInfoGraphQLIntegration.Tests.ps1` — 15/15 passing
- [x] Full existing suite (`Invoke-Pester -Path tests`) — 703 passed, 2 failed (confirmed pre-existing/unrelated on `main`: `Select-ForksToProcess` cool-off prioritization and Trivy scan-timing tests, both time-dependent and failing identically without this branch's changes), 3 skipped
- [x] `library.ps1` / `repoInfo.ps1` parse cleanly via `[System.Management.Automation.Language.Parser]::ParseFile`
- [x] `analyze.yml` parses as valid YAML
- [ ] Live run against `repoInfo.yml` / `analyze.yml` in GitHub Actions (needs real GitHub App credentials + blob storage, not exercisable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)