### PR TITLE
Reduce update-mirrors API calls via zero-cost skip and cached mirror SHA

### DIFF
--- a/.github/workflows/library.ps1
+++ b/.github/workflows/library.ps1
@@ -3716,46 +3716,60 @@ function Get-RepositoryDefaultBranchCommit {
     Param (
         [string] $owner,
         [string] $repo,
-        $access_token = $env:GITHUB_TOKEN
+        $access_token = $env:GITHUB_TOKEN,
+        # Optional: if the default branch is already known (e.g. from a prior repo-info
+        # call), pass it here to skip the initial GET /repos/{owner}/{repo} call.
+        [string] $knownDefaultBranch = $null
     )
-    
+
     # Get the latest commit SHA from the default branch of a repository using the GitHub API
-    # Returns a hashtable with success status, commit SHA, and branch name
+    # Returns a hashtable with success status, commit SHA, branch name, and (when the repo-info
+    # call is made) the repository's pushed_at timestamp - a single GET gives existence,
+    # pushed_at and default_branch together, so callers don't need a separate exists check.
     # This is more efficient than cloning the repo just to check if it's up to date
-    
+
     if ([string]::IsNullOrWhiteSpace($owner) -or [string]::IsNullOrWhiteSpace($repo)) {
         return @{
             success = $false
             sha = $null
             branch = $null
+            pushed_at = $null
             error = "Invalid owner or repo"
         }
     }
-    
+
     try {
-        # First get the repository info to find the default branch
-        $repoUrl = "repos/$owner/$repo"
-        $repoInfo = ApiCall -method GET -url $repoUrl -access_token $access_token -hideFailedCall $true
-        
-        if ($null -eq $repoInfo -or $repoInfo -eq $false) {
-            return @{
-                success = $false
-                sha = $null
-                branch = $null
-                error = "Repository not found"
-            }
-        }
-        
-        $defaultBranch = $repoInfo.default_branch
+        $defaultBranch = $knownDefaultBranch
+        $pushedAt = $null
+
         if ([string]::IsNullOrWhiteSpace($defaultBranch)) {
-            # Repository metadata may not have default_branch set; default to main
-            $defaultBranch = "main"
+            # First get the repository info to find the default branch (this same call also
+            # proves existence and returns pushed_at, so no separate exists check is needed)
+            $repoUrl = "repos/$owner/$repo"
+            $repoInfo = ApiCall -method GET -url $repoUrl -access_token $access_token -hideFailedCall $true
+
+            if ($null -eq $repoInfo -or $repoInfo -eq $false) {
+                return @{
+                    success = $false
+                    sha = $null
+                    branch = $null
+                    pushed_at = $null
+                    error = "Repository not found"
+                }
+            }
+
+            $defaultBranch = $repoInfo.default_branch
+            if ([string]::IsNullOrWhiteSpace($defaultBranch)) {
+                # Repository metadata may not have default_branch set; default to main
+                $defaultBranch = "main"
+            }
+            $pushedAt = $repoInfo.pushed_at
         }
-        
+
         # Get the latest commit from the default branch
         $branchUrl = "repos/$owner/$repo/branches/$defaultBranch"
         $branchInfo = ApiCall -method GET -url $branchUrl -access_token $access_token -hideFailedCall $true
-        
+
         if ($null -eq $branchInfo -or $branchInfo -eq $false) {
             # If the default branch is 'main' and wasn't found, try 'master' as some repos use it
             # This fallback only applies to 'main' since it's our default assumption
@@ -3765,20 +3779,22 @@ function Get-RepositoryDefaultBranchCommit {
                 $branchInfo = ApiCall -method GET -url $branchUrl -access_token $access_token -hideFailedCall $true
             }
         }
-        
+
         if ($null -eq $branchInfo -or $branchInfo -eq $false) {
             return @{
                 success = $false
                 sha = $null
                 branch = $defaultBranch
+                pushed_at = $pushedAt
                 error = "Branch not found"
             }
         }
-        
+
         return @{
             success = $true
             sha = $branchInfo.commit.sha
             branch = $defaultBranch
+            pushed_at = $pushedAt
             error = $null
         }
     }
@@ -3787,6 +3803,7 @@ function Get-RepositoryDefaultBranchCommit {
             success = $false
             sha = $null
             branch = $null
+            pushed_at = $null
             error = $_.Exception.Message
         }
     }
@@ -3798,16 +3815,22 @@ function Compare-RepositoryCommitHashes {
         [string] $sourceRepo,
         [string] $mirrorOwner,
         [string] $mirrorRepo,
-        $access_token = $env:GITHUB_TOKEN
+        $access_token = $env:GITHUB_TOKEN,
+        # Optional: a previously stored HEAD SHA for the mirror (e.g. status.json's
+        # mirrorCommitSha, captured after the last successful sync). When provided, the
+        # mirror-side existence check and commit lookup are skipped entirely, since we own
+        # all writes to the mirrors and can trust the last SHA we recorded there.
+        [string] $knownMirrorSha = $null
     )
-    
+
     # Compare the latest commit hashes of source and mirror repositories
     # Returns a hashtable indicating if they are in sync and the commit details
     # This allows early exit before expensive git clone/fetch operations
-    
+
     Write-Debug "Comparing commits: source [$sourceOwner/$sourceRepo] vs mirror [$mirrorOwner/$mirrorRepo]"
-    
-    # Get source repository commit
+
+    # Get source repository commit (this single call also proves the upstream repo exists
+    # and returns its pushed_at, so no separate upstream-exists call is needed)
     $sourceCommit = Get-RepositoryDefaultBranchCommit -owner $sourceOwner -repo $sourceRepo -access_token $access_token
     if (-not $sourceCommit.success) {
         return @{
@@ -3815,11 +3838,31 @@ function Compare-RepositoryCommitHashes {
             can_compare = $false
             source_sha = $null
             mirror_sha = $null
+            source_not_found = ($sourceCommit.error -eq "Repository not found")
+            mirror_not_found = $false
             error = "Could not get source commit: $($sourceCommit.error)"
         }
     }
-    
-    # Get mirror repository commit  
+
+    # Fast path: compare against a previously recorded mirror SHA without touching the
+    # mirror repo's API at all
+    if (-not [string]::IsNullOrWhiteSpace($knownMirrorSha)) {
+        $inSync = $sourceCommit.sha -eq $knownMirrorSha
+        return @{
+            in_sync = $inSync
+            can_compare = $true
+            source_sha = $sourceCommit.sha
+            mirror_sha = $knownMirrorSha
+            source_branch = $sourceCommit.branch
+            mirror_branch = $null
+            used_cached_mirror_sha = $true
+            source_not_found = $false
+            mirror_not_found = $false
+            error = $null
+        }
+    }
+
+    # No cached mirror SHA available - fall back to the full API-based comparison
     $mirrorCommit = Get-RepositoryDefaultBranchCommit -owner $mirrorOwner -repo $mirrorRepo -access_token $access_token
     if (-not $mirrorCommit.success) {
         return @{
@@ -3827,13 +3870,15 @@ function Compare-RepositoryCommitHashes {
             can_compare = $false
             source_sha = $sourceCommit.sha
             mirror_sha = $null
+            source_not_found = $false
+            mirror_not_found = ($mirrorCommit.error -eq "Repository not found")
             error = "Could not get mirror commit: $($mirrorCommit.error)"
         }
     }
-    
+
     # Compare the commit SHAs
     $inSync = $sourceCommit.sha -eq $mirrorCommit.sha
-    
+
     return @{
         in_sync = $inSync
         can_compare = $true
@@ -3841,6 +3886,9 @@ function Compare-RepositoryCommitHashes {
         mirror_sha = $mirrorCommit.sha
         source_branch = $sourceCommit.branch
         mirror_branch = $mirrorCommit.branch
+        used_cached_mirror_sha = $false
+        source_not_found = $false
+        mirror_not_found = $false
         error = $null
     }
 }
@@ -3998,7 +4046,12 @@ function SyncMirrorWithUpstream {
         $repo,
         $upstreamOwner,
         $upstreamRepo,
-        $access_token = $env:GITHUB_TOKEN
+        $access_token = $env:GITHUB_TOKEN,
+        # Optional: the mirror's HEAD SHA as recorded after the last successful sync
+        # (status.json's mirrorCommitSha). When present, it lets us skip the mirror-side
+        # existence check and commit lookup entirely - we own all writes to the mirrors,
+        # so a cached SHA is trustworthy. Falls back to the full API comparison when absent.
+        [string] $storedMirrorSha = $null
     )
     
     # Sync a mirror repository by pulling from upstream and pushing to mirror
@@ -4024,33 +4077,40 @@ function SyncMirrorWithUpstream {
         }
     }
     
-    # Check if upstream repository exists before attempting sync
-    $upstreamExists = Test-RepositoryExists -owner $upstreamOwner -repo $upstreamRepo -access_token $access_token
-    if (-not $upstreamExists) {
-        Write-Debug "Upstream repository [$upstreamOwner/$upstreamRepo] does not exist or is not accessible"
-        return @{
-            success = $false
-            message = "Upstream repository not found"
-            error_type = "upstream_not_found"
+    # Single API-based comparison collapses what used to be up to 4 separate calls
+    # (upstream exists, mirror exists, upstream commit, mirror commit) into as few as 2:
+    # - Get-RepositoryDefaultBranchCommit(upstream) proves existence + gives pushed_at +
+    #   default_branch + HEAD sha in one GET plus one branch GET
+    # - when a trustworthy cached mirror SHA is available, the mirror-side existence check
+    #   and commit lookup are skipped entirely (see Compare-RepositoryCommitHashes)
+    $comparison = Compare-RepositoryCommitHashes -sourceOwner $upstreamOwner -sourceRepo $upstreamRepo -mirrorOwner $owner -mirrorRepo $repo -access_token $access_token -knownMirrorSha $storedMirrorSha
+
+    if (-not $comparison.can_compare) {
+        if ($comparison.source_not_found) {
+            Write-Debug "Upstream repository [$upstreamOwner/$upstreamRepo] does not exist or is not accessible"
+            return @{
+                success = $false
+                message = "Upstream repository not found"
+                error_type = "upstream_not_found"
+            }
         }
-    }
-    
-    # Check if mirror repository exists
-    $mirrorExists = Test-RepositoryExists -owner $owner -repo $repo -access_token $access_token
-    if (-not $mirrorExists) {
-        Write-Debug "Mirror repository [$owner/$repo] does not exist"
-        return @{
-            success = $false
-            message = "Mirror repository not found"
-            error_type = "mirror_not_found"
+
+        if ($comparison.mirror_not_found) {
+            Write-Debug "Mirror repository [$owner/$repo] does not exist"
+            return @{
+                success = $false
+                message = "Mirror repository not found"
+                error_type = "mirror_not_found"
+            }
         }
+
+        # If comparison failed for another reason, continue with normal sync process
+        # (clone/fetch/merge). This handles cases where API comparison might fail but git
+        # operations could succeed, and covers the "trust the cached SHA, skip the mirror
+        # exists check" case where a deleted mirror is only discovered when git clone fails.
+        Write-Debug "Could not compare commits via API, proceeding with git-based sync: $($comparison.error)"
     }
-    
-    # Early sync detection: Compare commit hashes before cloning
-    # This avoids expensive git clone/fetch operations when repos are already in sync
-    $comparison = Compare-RepositoryCommitHashes -sourceOwner $upstreamOwner -sourceRepo $upstreamRepo -mirrorOwner $owner -mirrorRepo $repo -access_token $access_token
-    
-    if ($comparison.can_compare -and $comparison.in_sync) {
+    elseif ($comparison.in_sync) {
         Write-Debug "Mirror [$owner/$repo] is already in sync with upstream (SHA: $($comparison.source_sha))"
         return @{
             success = $true
@@ -4059,12 +4119,6 @@ function SyncMirrorWithUpstream {
             source_sha = $comparison.source_sha
             mirror_sha = $comparison.mirror_sha
         }
-    }
-    
-    # If comparison failed, continue with normal sync process (clone/fetch/merge)
-    # This handles cases where API comparison might fail but git operations could succeed
-    if (-not $comparison.can_compare) {
-        Write-Debug "Could not compare commits via API, proceeding with git-based sync: $($comparison.error)"
     }
     
     # Create temp directory if it doesn't exist
@@ -4322,6 +4376,7 @@ function SyncMirrorWithUpstream {
                     success = $true
                     message = "Already up to date"
                     merge_type = "none"
+                    mirror_sha = "$afterHash"
                 }
             }
         }
@@ -4381,6 +4436,7 @@ function SyncMirrorWithUpstream {
             success = $true
             message = $message
             merge_type = $mergeType
+            mirror_sha = "$afterHash"
         }
     }
     catch {
@@ -4628,6 +4684,8 @@ function Split-ActionsIntoChunks {
     - Forks that haven't been synced recently are prioritized
     - Failed sync attempts respect a cool-off period before retry
     - Upstream unavailable repos are skipped
+    - Forks whose upstream repoInfo.updated_at is not newer than lastSynced are skipped
+      with zero API calls, since there is nothing to sync
     
     .PARAMETER existingForks
     The complete array of fork objects from status.json
@@ -4659,6 +4717,7 @@ function Select-ForksToProcess {
     $filteredNoMirror = 0
     $filteredUpstreamUnavailable = 0
     $filteredCoolOff = 0
+    $filteredAlreadyUpToDate = 0
     
     # First pass: count each filter reason and collect eligible forks
     # Use generic List for better performance and type safety with large datasets
@@ -4691,10 +4750,29 @@ function Select-ForksToProcess {
             }
         }
         
+        # Zero-API-call skip: if we already know (from repoInfo.ps1's periodic upstream
+        # check) that the upstream repo hasn't been updated since our last successful
+        # sync, there is nothing to sync - skip without spending any API calls on it.
+        # Only trust this when both timestamps are present and parseable; otherwise fall
+        # through and let the normal sync path (which re-checks via the API) decide.
+        if ($fork.lastSynced -and $fork.repoInfo -and $fork.repoInfo.updated_at) {
+            try {
+                $upstreamUpdatedAt = [DateTime]::Parse($fork.repoInfo.updated_at)
+                $lastSyncedDate = [DateTime]::Parse($fork.lastSynced)
+                if ($upstreamUpdatedAt -le $lastSyncedDate) {
+                    $filteredAlreadyUpToDate++
+                    continue
+                }
+            } catch {
+                # Unparseable dates - do not skip, let the sync path re-check via the API
+                Write-Debug "Failed to parse repoInfo.updated_at/lastSynced for [$($fork.name)]"
+            }
+        }
+
         # This fork passed all filters
         [void]$eligibleForks.Add($fork)
     }
-    
+
     # Display filtering statistics
     Write-Message -message "" -logToSummary $true
     Write-Message -message "### Fork Selection Filtering Results" -logToSummary $true
@@ -4705,6 +4783,7 @@ function Select-ForksToProcess {
     Write-Message -message "| Filtered: No mirror found | $(DisplayIntWithDots $filteredNoMirror) |" -logToSummary $true
     Write-Message -message "| Filtered: Upstream unavailable | $(DisplayIntWithDots $filteredUpstreamUnavailable) |" -logToSummary $true
     Write-Message -message "| Filtered: In cool-off period (failed < ${coolOffHoursForFailedSync}h ago) | $(DisplayIntWithDots $filteredCoolOff) |" -logToSummary $true
+    Write-Message -message "| Filtered: Already up to date (0 API calls) | $(DisplayIntWithDots $filteredAlreadyUpToDate) |" -logToSummary $true
     Write-Message -message "| **Eligible forks after filtering** | **$(DisplayIntWithDots $eligibleForks.Count)** |" -logToSummary $true
     Write-Message -message "" -logToSummary $true
     
@@ -4809,6 +4888,7 @@ function Select-ForksToProcess {
     }
     
     Write-Message -message "- Eligible forks with recent failures: [$(DisplayIntWithDots $reposWithRecentFailures)] (deprioritized by smart sorting)" -logToSummary $true
+    Write-Message -message "- Skipped as already up to date (0 API calls): [$(DisplayIntWithDots $filteredAlreadyUpToDate)]" -logToSummary $true
     Write-Message -message "" -logToSummary $true
     
     return $selectedForks

--- a/.github/workflows/update-mirrors-chunk.ps1
+++ b/.github/workflows/update-mirrors-chunk.ps1
@@ -106,12 +106,13 @@ function UpdateForkedReposChunk {
 
         Write-Host "$($i+1)/$($forksToProcess.Count) Syncing mirror [actions-marketplace-validations/$($existingFork.name)] with upstream [$upstreamOwner/$upstreamRepo]"
         
-        $result = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination
-        
+        $storedMirrorSha = $existingFork.mirrorCommitSha
+        $result = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination -storedMirrorSha $storedMirrorSha
+
         if ($result.success) {
             # Update the sync timestamp for all successfully checked repos
             $existingFork | Add-Member -Name lastSynced -Value (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ") -MemberType NoteProperty -Force
-            
+
             if ($result.message -like "*Already up to date*") {
                 Write-Debug "Mirror [$($existingFork.name)] already up to date"
                 $upToDate++
@@ -123,6 +124,10 @@ function UpdateForkedReposChunk {
             else {
                 Write-Host "$i/$($forksToProcess.Count) Successfully synced mirror [$($existingFork.name)]"
                 $synced++
+            }
+            # Persist the mirror's HEAD SHA so future runs can skip the mirror-side API checks
+            if ($result.mirror_sha) {
+                $existingFork | Add-Member -Name mirrorCommitSha -Value $result.mirror_sha -MemberType NoteProperty -Force
             }
             # Clear any previous sync errors on success
             if (Get-Member -InputObject $existingFork -Name "lastSyncError" -MemberType Properties) {
@@ -169,11 +174,15 @@ function UpdateForkedReposChunk {
                     $mirrorsCreated++
                     $existingFork.mirrorFound = $true
                     Write-Host "Created mirror [$forkOrg/$($existingFork.name)], retrying sync"
-                    $retry = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination
+                    # A freshly created mirror has no cached SHA to trust yet
+                    $retry = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination -storedMirrorSha $null
                     if ($retry.success) {
                         Write-Host "Successfully synced newly created mirror [$($existingFork.name)]"
                         $synced++
                         $existingFork | Add-Member -Name lastSynced -Value (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ") -MemberType NoteProperty -Force
+                        if ($retry.mirror_sha) {
+                            $existingFork | Add-Member -Name mirrorCommitSha -Value $retry.mirror_sha -MemberType NoteProperty -Force
+                        }
                     }
                     else {
                         Write-Warning "Failed to sync newly created mirror [$($existingFork.name)]: $($retry.message)"

--- a/.github/workflows/update-mirrors-retry.ps1
+++ b/.github/workflows/update-mirrors-retry.ps1
@@ -78,7 +78,8 @@ foreach ($item in $ready) {
 
     if ($createResult) {
         Write-Host "Mirror created for [$mirrorName], attempting sync"
-        $sync = SyncMirrorWithUpstream -owner $forkOrg -repo $mirrorName -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination
+        # A freshly created mirror has no cached SHA to trust yet
+        $sync = SyncMirrorWithUpstream -owner $forkOrg -repo $mirrorName -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination -storedMirrorSha $null
         $syncSuccess = if ($sync -is [hashtable]) { $sync.success } else { $sync.success }
         if ($syncSuccess) {
             Write-Host "Successfully synced [$mirrorName]; removing from queue"

--- a/.github/workflows/update-mirrors.ps1
+++ b/.github/workflows/update-mirrors.ps1
@@ -60,13 +60,15 @@ function UpdateForkedRepos {
 
         Write-Host "$($i+1)/$max Syncing mirror [actions-marketplace-validations/$($existingFork.name)] with upstream [$upstreamOwner/$upstreamRepo]"
         
-        $result = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination
-        
+        $storedMirrorSha = if ($existingFork -is [hashtable]) { $existingFork["mirrorCommitSha"] } else { $existingFork.mirrorCommitSha }
+        $result = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination -storedMirrorSha $storedMirrorSha
+
         # Normalize result for hashtable or object
         $resultSuccess = if ($result -is [hashtable]) { $result["success"] } else { $result.success }
         $resultMessage = if ($result -is [hashtable]) { $result["message"] } else { $result.message }
         $resultErrorType = if ($result -is [hashtable]) { $result["error_type"] } else { $result.error_type }
         $resultMergeType = if ($result -is [hashtable]) { $result["merge_type"] } else { $result.merge_type }
+        $resultMirrorSha = if ($result -is [hashtable]) { $result["mirror_sha"] } else { $result.mirror_sha }
 
         if ($resultSuccess) {
             if ($resultMessage -like "*Already up to date*") {
@@ -77,7 +79,7 @@ function UpdateForkedRepos {
                 # Update the sync timestamp for any successful sync (merge or force update)
                 if ($existingFork -is [hashtable]) { $existingFork["lastSynced"] = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ") }
                 else { $existingFork | Add-Member -Name lastSynced -Value (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ") -MemberType NoteProperty -Force }
-                
+
                 if ($resultMergeType -eq "force_update") {
                     Write-Host "$i/$max Force updated mirror [$($existingFork.name)] (resolved merge conflict)"
                     $synced++
@@ -86,6 +88,11 @@ function UpdateForkedRepos {
                     Write-Host "$i/$max Successfully synced mirror [$($existingFork.name)]"
                     $synced++
                 }
+            }
+            # Persist the mirror's HEAD SHA so future runs can skip the mirror-side API checks
+            if ($resultMirrorSha) {
+                if ($existingFork -is [hashtable]) { $existingFork["mirrorCommitSha"] = $resultMirrorSha }
+                else { $existingFork | Add-Member -Name mirrorCommitSha -Value $resultMirrorSha -MemberType NoteProperty -Force }
             }
             # Clear any previous sync errors on success
             if (Get-Member -InputObject $existingFork -Name "lastSyncError" -MemberType Properties) {
@@ -144,14 +151,19 @@ function UpdateForkedRepos {
                     # Mark mirrorFound true and retry one sync
                     if ($existingFork -is [hashtable]) { $existingFork["mirrorFound"] = $true } else { $existingFork.mirrorFound = $true }
                     Write-Host "Created mirror [$forkOrg/$($existingFork.name)], retrying sync"
-                    $retry = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination
+                    # A freshly created mirror has no cached SHA to trust yet
+                    $retry = SyncMirrorWithUpstream -owner $forkOrg -repo $existingFork.name -upstreamOwner $upstreamOwner -upstreamRepo $upstreamRepo -access_token $access_token_destination -storedMirrorSha $null
                     # Normalize retry result
                     $retrySuccess = if ($retry -is [hashtable]) { $retry["success"] } else { $retry.success }
                     $retryMessage = if ($retry -is [hashtable]) { $retry["message"] } else { $retry.message }
                     $retryErrorType = if ($retry -is [hashtable]) { $retry["error_type"] } else { $retry.error_type }
+                    $retryMirrorSha = if ($retry -is [hashtable]) { $retry["mirror_sha"] } else { $retry.mirror_sha }
                     if ($retrySuccess) {
                         if ($retryMessage -like "*Already up to date*") { $upToDate++ } else { $synced++ }
                         if ($existingFork -is [hashtable]) { $existingFork["lastSynced"] = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ") } else { $existingFork | Add-Member -Name lastSynced -Value (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ") -MemberType NoteProperty -Force }
+                        if ($retryMirrorSha) {
+                            if ($existingFork -is [hashtable]) { $existingFork["mirrorCommitSha"] = $retryMirrorSha } else { $existingFork | Add-Member -Name mirrorCommitSha -Value $retryMirrorSha -MemberType NoteProperty -Force }
+                        }
                         if (Get-Member -InputObject $existingFork -Name "lastSyncError" -MemberType Properties) { if ($existingFork -is [hashtable]) { $existingFork["lastSyncError"] = $null } else { $existingFork.lastSyncError = $null } }
                     }
                     else {

--- a/.github/workflows/validate-status-schema.ps1
+++ b/.github/workflows/validate-status-schema.ps1
@@ -55,6 +55,7 @@ class StatusJsonSchema {
     [object] $forkFound  # Can be boolean or null
     [object] $mirrorLastUpdated  # Can be string (datetime) or null
     [object] $repoSize  # Can be int or null
+    [object] $mirrorCommitSha  # Can be string (git SHA) or null; set after a successful mirror sync
     
     # Action type information (typically present but can have varied content)
     [object] $actionType  # Hashtable with fileFound, actionType, nodeVersion, actionDockerType, dockerBaseImage, dockerfileHasCustomCode, containerScan

--- a/tests/mirrorSyncApiCallReduction.Tests.ps1
+++ b/tests/mirrorSyncApiCallReduction.Tests.ps1
@@ -1,0 +1,215 @@
+BeforeAll {
+    # Import the library functions
+    . $PSScriptRoot/../.github/workflows/library.ps1
+}
+
+Describe "Get-RepositoryDefaultBranchCommit collapsed existence+pushed_at+default_branch call" {
+    It "Should return pushed_at and branch from a single repo-info call plus one branch call" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "abc123" } }
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = Get-RepositoryDefaultBranchCommit -owner "upstreamOwner" -repo "upstreamRepo" -access_token "test_token"
+
+        $result.success | Should -Be $true
+        $result.sha | Should -Be "abc123"
+        $result.branch | Should -Be "main"
+        $result.pushed_at | Should -Be "2025-12-20T00:00:00Z"
+        Should -Invoke ApiCall -Times 2
+    }
+
+    It "Should skip the repo-info call when knownDefaultBranch is provided" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/develop") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "def456" } }
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = Get-RepositoryDefaultBranchCommit -owner "upstreamOwner" -repo "upstreamRepo" -access_token "test_token" -knownDefaultBranch "develop"
+
+        $result.success | Should -Be $true
+        $result.sha | Should -Be "def456"
+        Should -Invoke ApiCall -Times 1
+    }
+
+    It "Should report Repository not found without a branch call when the repo does not exist" {
+        Mock ApiCall { return $null }
+
+        $result = Get-RepositoryDefaultBranchCommit -owner "ghost" -repo "repo" -access_token "test_token"
+
+        $result.success | Should -Be $false
+        $result.error | Should -Be "Repository not found"
+        Should -Invoke ApiCall -Times 1
+    }
+}
+
+Describe "Compare-RepositoryCommitHashes with a cached mirror SHA" {
+    It "Should report in_sync using only the source-side call when SHAs match" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "same-sha" } }
+            }
+            throw "Unexpected URL called: $url (mirror side should not be queried)"
+        }
+
+        $result = Compare-RepositoryCommitHashes -sourceOwner "upstreamOwner" -sourceRepo "upstreamRepo" -mirrorOwner "mirrorOrg" -mirrorRepo "mirrorRepo" -access_token "test_token" -knownMirrorSha "same-sha"
+
+        $result.can_compare | Should -Be $true
+        $result.in_sync | Should -Be $true
+        $result.used_cached_mirror_sha | Should -Be $true
+        # Only the 2 upstream calls (repo-info + branch) should have happened
+        Should -Invoke ApiCall -Times 2
+    }
+
+    It "Should report not in_sync using only the source-side call when SHAs differ" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "new-upstream-sha" } }
+            }
+            throw "Unexpected URL called: $url (mirror side should not be queried)"
+        }
+
+        $result = Compare-RepositoryCommitHashes -sourceOwner "upstreamOwner" -sourceRepo "upstreamRepo" -mirrorOwner "mirrorOrg" -mirrorRepo "mirrorRepo" -access_token "test_token" -knownMirrorSha "stale-mirror-sha"
+
+        $result.can_compare | Should -Be $true
+        $result.in_sync | Should -Be $false
+        $result.source_sha | Should -Be "new-upstream-sha"
+        $result.mirror_sha | Should -Be "stale-mirror-sha"
+        Should -Invoke ApiCall -Times 2
+    }
+
+    It "Should fall back to querying the mirror repo when no cached SHA is provided" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "sha-1" } }
+            }
+            if ($url -eq "repos/mirrorOrg/mirrorRepo") {
+                return [PSCustomObject]@{ default_branch = "main" }
+            }
+            if ($url -eq "repos/mirrorOrg/mirrorRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "sha-1" } }
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = Compare-RepositoryCommitHashes -sourceOwner "upstreamOwner" -sourceRepo "upstreamRepo" -mirrorOwner "mirrorOrg" -mirrorRepo "mirrorRepo" -access_token "test_token"
+
+        $result.can_compare | Should -Be $true
+        $result.in_sync | Should -Be $true
+        $result.used_cached_mirror_sha | Should -Be $false
+        Should -Invoke ApiCall -Times 4
+    }
+
+    It "Should flag mirror_not_found when the mirror repo does not exist and no cached SHA is given" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "sha-1" } }
+            }
+            if ($url -eq "repos/mirrorOrg/mirrorRepo") {
+                return $null
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = Compare-RepositoryCommitHashes -sourceOwner "upstreamOwner" -sourceRepo "upstreamRepo" -mirrorOwner "mirrorOrg" -mirrorRepo "mirrorRepo" -access_token "test_token"
+
+        $result.can_compare | Should -Be $false
+        $result.mirror_not_found | Should -Be $true
+    }
+
+    It "Should flag source_not_found when the upstream repo does not exist" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return $null
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = Compare-RepositoryCommitHashes -sourceOwner "upstreamOwner" -sourceRepo "upstreamRepo" -mirrorOwner "mirrorOrg" -mirrorRepo "mirrorRepo" -access_token "test_token" -knownMirrorSha "anything"
+
+        $result.can_compare | Should -Be $false
+        $result.source_not_found | Should -Be $true
+        # Should not have attempted a second call for the branch
+        Should -Invoke ApiCall -Times 1
+    }
+}
+
+Describe "SyncMirrorWithUpstream API-call reduction" {
+    It "Should have a storedMirrorSha parameter" {
+        $command = Get-Command SyncMirrorWithUpstream
+        $command.Parameters.Keys | Should -Contain "storedMirrorSha"
+    }
+
+    It "Should report Already up to date via cached SHA without ever calling the mirror repo" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "matching-sha" } }
+            }
+            throw "Unexpected URL called: $url (mirror repo should not be queried when cached SHA matches)"
+        }
+
+        $result = SyncMirrorWithUpstream -owner "mirrorOrg" -repo "mirrorRepo" -upstreamOwner "upstreamOwner" -upstreamRepo "upstreamRepo" -access_token "test_token" -storedMirrorSha "matching-sha"
+
+        $result.success | Should -Be $true
+        $result.message | Should -Be "Already up to date"
+        $result.mirror_sha | Should -Be "matching-sha"
+        Should -Invoke ApiCall -Times 2
+    }
+
+    It "Should return upstream_not_found without any mirror-side call" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/missingRepo") {
+                return $null
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = SyncMirrorWithUpstream -owner "mirrorOrg" -repo "mirrorRepo" -upstreamOwner "upstreamOwner" -upstreamRepo "missingRepo" -access_token "test_token" -storedMirrorSha "some-sha"
+
+        $result.success | Should -Be $false
+        $result.error_type | Should -Be "upstream_not_found"
+        Should -Invoke ApiCall -Times 1
+    }
+
+    It "Should return mirror_not_found via the API fallback when no cached SHA is available" {
+        Mock ApiCall {
+            if ($url -eq "repos/upstreamOwner/upstreamRepo") {
+                return [PSCustomObject]@{ default_branch = "main"; pushed_at = "2025-12-20T00:00:00Z" }
+            }
+            if ($url -eq "repos/upstreamOwner/upstreamRepo/branches/main") {
+                return [PSCustomObject]@{ commit = [PSCustomObject]@{ sha = "sha-1" } }
+            }
+            if ($url -eq "repos/mirrorOrg/missingMirror") {
+                return $null
+            }
+            throw "Unexpected URL: $url"
+        }
+
+        $result = SyncMirrorWithUpstream -owner "mirrorOrg" -repo "missingMirror" -upstreamOwner "upstreamOwner" -upstreamRepo "upstreamRepo" -access_token "test_token"
+
+        $result.success | Should -Be $false
+        $result.error_type | Should -Be "mirror_not_found"
+    }
+}

--- a/tests/selectForksToProcess.Tests.ps1
+++ b/tests/selectForksToProcess.Tests.ps1
@@ -157,6 +157,120 @@ Describe "Select-ForksToProcess" {
         }
     }
     
+    Context "Zero-API-call skip when upstream has not changed" {
+        It "Should skip a fork when repoInfo.updated_at is older than lastSynced" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "upToDateFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                    repoInfo = [PSCustomObject]@{ updated_at = "2025-12-10T00:00:00Z" }
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 0
+        }
+
+        It "Should skip a fork when repoInfo.updated_at equals lastSynced" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "upToDateFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                    repoInfo = [PSCustomObject]@{ updated_at = "2025-12-15T12:00:00Z" }
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 0
+        }
+
+        It "Should still select a fork when repoInfo.updated_at is newer than lastSynced" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "staleFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                    repoInfo = [PSCustomObject]@{ updated_at = "2025-12-16T00:00:00Z" }
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 1
+            $result[0].name | Should -Be "staleFork"
+        }
+
+        It "Should still select a fork that has never been synced, even with repoInfo present" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "neverSyncedFork"
+                    mirrorFound = $true
+                    lastSynced = $null
+                    repoInfo = [PSCustomObject]@{ updated_at = "2020-01-01T00:00:00Z" }
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 1
+        }
+
+        It "Should still select a fork with no repoInfo at all" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "noRepoInfoFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 1
+        }
+
+        It "Should not skip when repoInfo.updated_at is unparseable" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "badDateFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                    repoInfo = [PSCustomObject]@{ updated_at = "not-a-date" }
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 1
+        }
+
+        It "Should mix skipped up-to-date forks with forks that still need syncing" {
+            $forks = @(
+                [PSCustomObject]@{
+                    name = "upToDateFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                    repoInfo = [PSCustomObject]@{ updated_at = "2025-12-10T00:00:00Z" }
+                }
+                [PSCustomObject]@{
+                    name = "needsSyncFork"
+                    mirrorFound = $true
+                    lastSynced = "2025-12-15T12:00:00Z"
+                    repoInfo = [PSCustomObject]@{ updated_at = "2025-12-20T00:00:00Z" }
+                }
+            )
+
+            $result = Select-ForksToProcess -existingForks $forks -numberOfRepos 10
+
+            $result.Count | Should -Be 1
+            $result[0].name | Should -Be "needsSyncFork"
+        }
+    }
+
     Context "Limit enforcement" {
         It "Should respect the numberOfRepos limit" {
             $forks = @()


### PR DESCRIPTION
## Summary

The hourly `update-mirrors` workflow selects up to 300 mirrors/hour (`Select-ForksToProcess`) and, even when a mirror is already up to date, spends several API calls per mirror just to discover that. This PR cuts that cost in two ways:

1. **Zero-call skip in `Select-ForksToProcess`**: a mirror is dropped from the candidate list entirely when `repoInfo.updated_at` (the upstream's last known update timestamp, refreshed periodically by `repoInfo.ps1`) is not newer than the mirror's `lastSynced` — there is nothing to sync, so it costs 0 API calls this run. (Note: the task description referenced `mirrorLastUpdated` for this purpose, but that field actually reflects the *mirror's own* `updated_at`, not the upstream's — it moves in lockstep with our own pushes and wouldn't detect upstream changes. `repoInfo.updated_at`, populated from the upstream repo, is the correct signal and is what this PR uses.)

2. **Collapsed per-mirror API calls** for mirrors that do need checking:
   - `Get-RepositoryDefaultBranchCommit`'s existing repo-info GET now also returns `pushed_at`, so the previously separate `Test-RepositoryExists(upstream)` call is gone — existence, `pushed_at`, and `default_branch` all come from one GET.
   - `SyncMirrorWithUpstream` now accepts a `storedMirrorSha` (persisted to status.json as `mirrorCommitSha` after every successful sync). When present, the mirror-side existence check and commit lookup are skipped entirely and compared directly against the upstream SHA — safe because this project owns all writes to the mirrors. If the mirror was actually deleted, the git clone step's existing not-found detection still classifies it as `mirror_not_found`.
   - When no cached SHA is available (fresh mirror, or upgrading from before this change), the full API-based comparison runs as before.

`mirror_not_found` / `upstream_not_found` recovery paths in `update-mirrors.ps1`, `update-mirrors-chunk.ps1`, and `update-mirrors-retry.ps1` are unchanged — mirror creation via `ForkActionRepo` still triggers on the same error types.

### Rough API-call impact (300 mirrors/hour)

| | Before | After |
|---|---|---|
| Per mirror already in sync (repoInfo confirms no upstream change) | ~4-6 calls | **0 calls** |
| Per mirror needing a real check (cached SHA available) | ~4-6 calls | **~2 calls** (upstream repo-info + branch) |
| Per mirror with no cached SHA yet | ~4-6 calls | ~4 calls (same as before, existence calls removed) |

Exact savings depend on how many of the ~29k mirrors have both `lastSynced` and a fresh-enough `repoInfo.updated_at`, but a meaningful fraction of the hourly 300-mirror batch should now cost zero calls, and the rest drop from up to 6 calls to roughly 2.

## Test plan

- [x] Added `tests/mirrorSyncApiCallReduction.Tests.ps1` — mocks `ApiCall` to verify: `Get-RepositoryDefaultBranchCommit` returns `pushed_at` from a single repo-info call and can skip it via `knownDefaultBranch`; `Compare-RepositoryCommitHashes` uses only the upstream-side call when a cached mirror SHA is supplied (both match and mismatch cases) and falls back to the full comparison otherwise; `SyncMirrorWithUpstream` reports "Already up to date" via cached SHA without ever touching the mirror repo, and preserves `upstream_not_found`/`mirror_not_found` classification.
- [x] Extended `tests/selectForksToProcess.Tests.ps1` with cases for the new zero-call skip (older/equal/newer `repoInfo.updated_at`, never-synced forks, missing `repoInfo`, unparseable dates, mixed skip+sync batches).
- [x] Ran the full Pester suite (`Invoke-Pester -Path tests`) — 707 passed; the 2 failures present are pre-existing/time-flaky tests unrelated to this change (verified identical failures on `main` before these edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)