### PR TITLE
Add ETag/If-None-Match conditional request support to ApiCall

### DIFF
--- a/.github/workflows/library.ps1
+++ b/.github/workflows/library.ps1
@@ -913,6 +913,26 @@ function Get-JsonFromBlobStorageFolder {
     }
 }
 
+function Get-ApiCallSuccessResult {
+    <#
+    .SYNOPSIS
+        Shapes a successful ApiCall response. When the caller opted into
+        conditional-request support (-returnETag), the raw body is wrapped so it can
+        be told apart from a 304-Not-Modified result; otherwise the raw body is
+        returned unchanged for backward compatibility.
+    #>
+    Param (
+        $response,
+        $newEtag,
+        [bool] $returnETag
+    )
+
+    if ($returnETag) {
+        return @{ NotModified = $false; ETag = $newEtag; Data = $response }
+    }
+    return $response
+}
+
 function ApiCall {
     Param (
         $method,
@@ -931,7 +951,18 @@ function ApiCall {
         [int] $maxRetries = 10,
         [int] $appSwitchCount = 0,
         [int] $maxAppSwitchCount = 1,
-        [System.Collections.Generic.HashSet[string]] $triedAppIds = $null
+        [System.Collections.Generic.HashSet[string]] $triedAppIds = $null,
+        # Conditional request support (ETag / If-None-Match). GitHub does not count
+        # 304 Not Modified responses against the core rate limit, so callers that poll
+        # the same resource repeatedly (repo metadata, releases, tags) can pass in the
+        # ETag they stored from the previous successful response to make "check if
+        # anything changed" calls effectively free.
+        #
+        # Only takes effect when $returnETag is true, so existing callers that don't
+        # opt in keep getting the raw response body exactly as before. When opted in,
+        # both the success and 304 paths return a hashtable: @{ NotModified; ETag; Data }
+        [string] $etag = $null,
+        [bool] $returnETag = $false
     )
     
     # Use the script-scoped HashSet to track tried apps across all API calls
@@ -983,7 +1014,7 @@ function ApiCall {
                         Write-Host "✓ Switched to GitHub App id [$($betterToken.AppId)] with $($betterToken.MinutesUntilExpiration) minutes until expiration"
                         $env:GITHUB_TOKEN = $betterToken.Token
                         # Retry the API call with the fresh token
-                        return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $betterToken.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount $retryCount -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                        return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $betterToken.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount $retryCount -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                     } elseif ($null -eq $betterToken) {
                         # All tokens are expiring soon or exhausted - stop gracefully
                         $message = "⚠️ All available GitHub App tokens will expire within 15 minutes. Stopping gracefully to prevent mid-execution failures."
@@ -1003,6 +1034,9 @@ function ApiCall {
     if ($null -ne $body) {
         $headers.Add('Content-Type', 'application/json')
         $headers.Add('User-Agent', 'rajbos')
+    }
+    if ($returnETag -and -not [string]::IsNullOrWhiteSpace($etag)) {
+        $headers.Add('If-None-Match', $etag)
     }
 
     # prevent errors with empty urls
@@ -1043,7 +1077,15 @@ function ApiCall {
             $response = $result.Content
         }
         #Write-Host "Got this response: $($response | ConvertTo-Json)"
-        # todo: check and handle the rate limit headers
+        # Rate limit headers are logged below and enforced further down via the
+        # X-RateLimit-Remaining/Reset handling. ETag is captured here so callers
+        # that opt in via -returnETag can cache it and send it back as
+        # If-None-Match on their next call, turning "check if anything changed"
+        # into a free (non-rate-limited) 304 response.
+        $newEtag = $null
+        if ($result.Headers["ETag"]) {
+            $newEtag = $result.Headers["ETag"][0]
+        }
         Write-Debug "  StatusCode: $($result.StatusCode)"
         Write-Debug "  RateLimit-Limit: $($result.Headers["X-RateLimit-Limit"])"
         Write-Debug "  RateLimit-Remaining: $($result.Headers["X-RateLimit-Remaining"])"
@@ -1070,7 +1112,7 @@ function ApiCall {
                         # check if we need to stop getting more pages
                         if ($currentResultCount -gt $maxResultCount) {
                             Write-Host "Stopping with [$($currentResultCount)] results, which is more then the max result count [$maxResultCount]"
-                            return $response
+                            return (Get-ApiCallSuccessResult -response $response -newEtag $newEtag -returnETag $returnETag)
                         }
                     }
 
@@ -1138,7 +1180,7 @@ function ApiCall {
                                 # GITHUB_TOKEN will immediately use this app instead
                                 # of continuing to hit the exhausted token.
                                 $env:GITHUB_TOKEN = $bestBeforeWait.Token
-                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $bestBeforeWait.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $bestBeforeWait.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                             }
 
                             # All untried apps are currently exhausted. Check if ALL configured apps
@@ -1199,7 +1241,7 @@ function ApiCall {
                                         Write-Host "Cleared tried apps tracking after detecting rate limit reset (reset cycle count: $($script:ConsecutiveResetDetections))"
                                         
                                         # Retry immediately with cleared tried apps - don't wait
-                                        return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $access_token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                        return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $access_token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                                     } else {
                                         # False positive - don't clear tried apps, continue with normal flow
                                         Write-Host "Continuing with normal rate limit handling (not clearing tried apps)"
@@ -1235,7 +1277,7 @@ function ApiCall {
                                 $triedAppIds.Add($bestAfterWait.AppId) | Out-Null
                                 
                                 Write-Host "After waiting for rate limit reset, selected GitHub App id [$($bestAfterWait.AppId)] with [$($bestAfterWait.Remaining)] remaining requests"
-                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $bestAfterWait.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $bestAfterWait.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                             }
 
                             $message = "Rate limit did not recover after waiting across all apps; stopping execution"
@@ -1257,7 +1299,7 @@ function ApiCall {
 
                     # When waitForRateLimit is false and remaining is 0, just return
                     # the partial/empty response we already have without waiting.
-                    return $response
+                    return (Get-ApiCallSuccessResult -response $response -newEtag $newEtag -returnETag $returnETag)
                 }
 
                 if ($rateLimitReset.TotalSeconds -gt 1200) {
@@ -1274,7 +1316,7 @@ function ApiCall {
                                 if ($null -ne $tokenResult -and -not [string]::IsNullOrWhiteSpace($tokenResult.Token)) {
                                     $newToken = $tokenResult.Token
                                     Write-Host "Switched to GitHub App id [$($tokenResult.AppId)] after rate limit; retrying API call"
-                                    return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $newToken -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount $retryCount -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                    return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $newToken -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount $retryCount -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                                 }
                             }
                             catch {
@@ -1294,7 +1336,7 @@ function ApiCall {
                     }
                     # When not waiting for rate limits, just return the response we already have
                     # Don't show error messages or set the flag since we're intentionally not halting
-                    return $response
+                    return (Get-ApiCallSuccessResult -response $response -newEtag $newEtag -returnETag $returnETag)
                 }
                 Format-RateLimitErrorTable -remaining $rateLimitRemaining[0] -used $rateLimitUsed[0] -waitSeconds $rateLimitReset.TotalSeconds -continueAt $oUNIXDate -errorType "Warning"
                 Write-Host ""
@@ -1310,7 +1352,7 @@ function ApiCall {
             else {
                 $backOff = $backOff * 2
             }
-            return ApiCall -method $method -url $url -body $body -expected $expected -backOff ($backOff) -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount
+            return ApiCall -method $method -url $url -body $body -expected $expected -backOff ($backOff) -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount -etag $etag -returnETag $returnETag
         }
 
         if ($null -ne $expected) {
@@ -1323,10 +1365,25 @@ function ApiCall {
             }
         }
 
-        return $response
+        return (Get-ApiCallSuccessResult -response $response -newEtag $newEtag -returnETag $returnETag)
     }
     catch
     {
+        # 304 Not Modified: this only happens when we opted into conditional requests
+        # (If-None-Match was sent above) and the resource hasn't changed since the
+        # ETag we sent was captured. Invoke-WebRequest treats any non-2xx status as a
+        # terminating error, so a 304 lands here rather than in the try block - handle
+        # it first, before any of the retry/rate-limit/error-logging logic below, since
+        # it is not an error and must never trigger a retry or be counted as a failure.
+        $caughtStatusCode = $null
+        if ($null -ne $_.Exception -and $null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+            $caughtStatusCode = [int]$_.Exception.Response.StatusCode
+        }
+        if ($returnETag -and $caughtStatusCode -eq 304) {
+            Write-Debug "ApiCall received 304 Not Modified for [$url] - resource unchanged, not counted against rate limit"
+            return @{ NotModified = $true; ETag = $etag; Data = $null }
+        }
+
         try {
             $messageData = $_.ErrorDetails.Message | ConvertFrom-Json
         }
@@ -1348,7 +1405,7 @@ function ApiCall {
             Write-Host "Rate limit exceeded, waiting for [$backOff] seconds before continuing"
             Start-Sleep -Seconds $backOff
             GetRateLimitInfo -access_token $access_token -access_token_destination $access_token
-            return ApiCall -method $method -url $url -body $body -expected $expected -backOff ($backOff*2) -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount
+            return ApiCall -method $method -url $url -body $body -expected $expected -backOff ($backOff*2) -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount -etag $etag -returnETag $returnETag
         }
         else {
             if (!$hideFailedCall) {
@@ -1372,7 +1429,7 @@ function ApiCall {
             Write-Host "Secondary rate limit exceeded, waiting for [$backOff] seconds before continuing"
             Start-Sleep -Seconds $backOff
 
-            return ApiCall -method $method -url $url -body $body -expected $expected -backOff $backOff -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount
+            return ApiCall -method $method -url $url -body $body -expected $expected -backOff $backOff -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount -etag $etag -returnETag $returnETag
         }
 
         $isUserRateLimit = $messageData.message -and $messageData.message.StartsWith("API rate limit exceeded for user ID")
@@ -1469,7 +1526,7 @@ function ApiCall {
                                 Write-Host "Cleared tried apps tracking after detecting rate limit reset (reset cycle count: $($script:ConsecutiveResetDetections))"
                                 
                                 # Retry immediately with cleared tried apps - don't wait
-                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $access_token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $access_token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                             } else {
                                 # False positive - don't clear tried apps, continue with normal flow
                                 Write-Host "Continuing with normal rate limit handling (not clearing tried apps)"
@@ -1492,7 +1549,7 @@ function ApiCall {
                     # that don't explicitly pass access_token pick up the
                     # rotated app token instead of the exhausted one.
                     $env:GITHUB_TOKEN = $bestBeforeWait.Token
-                    return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $bestBeforeWait.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                    return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $bestBeforeWait.Token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                 } elseif ($null -ne $bestBeforeWait -and $bestBeforeWait.WaitSeconds -gt 0) {
                     # All untried apps are currently exhausted. Check if ALL configured apps
                     # (including tried ones) are exhausted. If so, use the shortest wait across ALL apps.
@@ -1555,7 +1612,7 @@ function ApiCall {
                                 Write-Host "Cleared tried apps tracking after detecting rate limit reset (reset cycle count: $($script:ConsecutiveResetDetections))"
                                 
                                 # Retry immediately with cleared tried apps - don't wait
-                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $access_token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $access_token -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                             } else {
                                 # False positive - don't clear tried apps, continue with normal flow
                                 Write-Host "Continuing with normal rate limit handling (not clearing tried apps)"
@@ -1591,7 +1648,7 @@ function ApiCall {
                                 # Update the shared environment token so future
                                 # calls use this app id by default.
                                 $env:GITHUB_TOKEN = $newToken
-                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $newToken -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount $retryCount -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds
+                                return ApiCall -method $method -url $url -body $body -expected $expected -currentResultCount $currentResultCount -backOff $backOff -maxResultCount $maxResultCount -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -access_token $newToken -contextInfo $contextInfo -waitForRateLimit $waitForRateLimit -retryCount $retryCount -maxRetries $maxRetries -appSwitchCount ($appSwitchCount + 1) -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -etag $etag -returnETag $returnETag
                             }
                         }
                         catch {
@@ -1704,7 +1761,7 @@ function ApiCall {
                 else {
                     $backOff = $backOff * 2
                 }
-                return ApiCall -method $method -url $url -body $body -expected $expected -backOff ($backOff) -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount
+                return ApiCall -method $method -url $url -body $body -expected $expected -backOff ($backOff) -access_token $access_token -waitForRateLimit $waitForRateLimit -retryCount ($retryCount + 1) -maxRetries $maxRetries -appSwitchCount $appSwitchCount -maxAppSwitchCount $maxAppSwitchCount -triedAppIds $triedAppIds -hideFailedCall $hideFailedCall -returnErrorInfo $returnErrorInfo -contextInfo $contextInfo -maxResultCount $maxResultCount -currentResultCount $currentResultCount -etag $etag -returnETag $returnETag
             }
 
             # When not waiting, return null
@@ -1899,12 +1956,17 @@ function GetOrgActionInfo {
 function GetRepoTagInfo {
     # Shared with releaseInfo-refresh.ps1 - keep this the single source of truth
     # for how tag information is fetched so both callers stay consistent.
+    #
+    # Always returns a hashtable @{ NotModified; ETag; Data }. Pass in the ETag
+    # stored from a previous call to make an unchanged repo's tags come back as a
+    # free 304 (not counted against the core rate limit) instead of a full call.
     Param (
         $owner,
         $repo,
         [Alias('access_token')]
         $accessToken,
-        $startTime
+        $startTime,
+        $etag = $null
     )
 
     if ($null -eq $owner -or $owner.Length -eq 0) {
@@ -1919,39 +1981,51 @@ function GetRepoTagInfo {
     }
 
     $url = "repos/$owner/$repo/git/matching-refs/tags"
-    $response = ApiCall -method GET -url $url -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken
+    $response = ApiCall -method GET -url $url -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken -etag $etag -returnETag $true
 
     if ($response -is [hashtable] -and $response.Error) {
         if ($response.StatusCode -ne 404) {
             Write-Host "Error loading tags for [$owner/$repo]: StatusCode [$($response.StatusCode)]"
         }
-        return @()
+        return @{ NotModified = $false; ETag = $null; Data = @() }
     }
 
-    if ($null -eq $response) {
-        return @()
+    if ($response -is [hashtable] -and $response.NotModified) {
+        Write-Host "Tags for [$owner/$repo] are unchanged (304 Not Modified) - call was free, not counted against rate limit"
+        return @{ NotModified = $true; ETag = $response.ETag; Data = $null }
     }
+
+    if ($null -eq $response -or $null -eq $response.Data) {
+        return @{ NotModified = $false; ETag = $null; Data = @() }
+    }
+
+    $newEtag = $response.ETag
 
     # Return array of objects with tag name and SHA
-    $response = $response | ForEach-Object {
+    $response = $response.Data | ForEach-Object {
         @{
             tag = SplitUrlLastPart($_.ref)
             sha = $_.object.sha
         }
     }
 
-    return $response
+    return @{ NotModified = $false; ETag = $newEtag; Data = $response }
 }
 
 function GetRepoReleases {
     # Shared with releaseInfo-refresh.ps1 - keep this the single source of truth
     # for how release information is fetched so both callers stay consistent.
+    #
+    # Always returns a hashtable @{ NotModified; ETag; Data }. Pass in the ETag
+    # stored from a previous call to make an unchanged repo's releases come back as
+    # a free 304 (not counted against the core rate limit) instead of a full call.
     Param (
         $owner,
         $repo,
         [Alias('access_token')]
         $accessToken,
-        $startTime
+        $startTime,
+        $etag = $null
     )
 
     if ($null -eq $owner -or $owner.Length -eq 0) {
@@ -1966,29 +2040,36 @@ function GetRepoReleases {
     }
 
     $url = "repos/$owner/$repo/releases"
-    $response = ApiCall -method GET -url $url -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken
+    $response = ApiCall -method GET -url $url -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken -etag $etag -returnETag $true
 
     if ($response -is [hashtable] -and $response.Error) {
         if ($response.StatusCode -ne 404) {
             Write-Host "Error loading releases for [$owner/$repo]: StatusCode [$($response.StatusCode)]"
         }
-        return @()
+        return @{ NotModified = $false; ETag = $null; Data = @() }
     }
 
-    if ($null -eq $response) {
-        return @()
+    if ($response -is [hashtable] -and $response.NotModified) {
+        Write-Host "Releases for [$owner/$repo] are unchanged (304 Not Modified) - call was free, not counted against rate limit"
+        return @{ NotModified = $true; ETag = $response.ETag; Data = $null }
     }
+
+    if ($null -eq $response -or $null -eq $response.Data) {
+        return @{ NotModified = $false; ETag = $null; Data = @() }
+    }
+
+    $newEtag = $response.ETag
 
     # Return array of objects with tag name and target_commitish (SHA)
     # Note: tag_name from releases API is already a direct string, not a URL path
-    $response = $response | ForEach-Object {
+    $response = $response.Data | ForEach-Object {
         @{
             tag_name = $_.tag_name
             target_commitish = $_.target_commitish
         }
     }
 
-    return $response
+    return @{ NotModified = $false; ETag = $newEtag; Data = $response }
 }
 
 function Invoke-GraphQLRepoMetadataBatch {

--- a/.github/workflows/releaseInfo-refresh.ps1
+++ b/.github/workflows/releaseInfo-refresh.ps1
@@ -121,15 +121,37 @@ function Update-VersionInfoForAction {
 
     Write-Host "Refreshing tag/release info for [$owner/$repo]"
 
-    $tagInfo = GetRepoTagInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
-    if ($null -ne $tagInfo) {
-        if (Get-Member -InputObject $action -Name "tagInfo" -MemberType Properties) {
-            $action.tagInfo = $tagInfo
-        }
-        else {
-            $action | Add-Member -Name tagInfo -Value $tagInfo -MemberType NoteProperty
+    # Sending back the ETag we stored last time turns an unchanged repo's tags/releases
+    # into a free 304 (not counted against the core rate limit) instead of a full call -
+    # this is the dominant case for the vast majority of the ~29k tracked actions on any
+    # given hourly run, since most repos don't cut a new tag/release every hour.
+    $existingTagEtagField = Get-Member -InputObject $action -Name "tagInfoEtag" -MemberType Properties
+    $existingTagEtag = if ($existingTagEtagField) { $action.tagInfoEtag } else { $null }
+    $tagResult = GetRepoTagInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime -etag $existingTagEtag
+    $tagInfoChanged = $false
+    if ($null -ne $tagResult) {
+        if (-not $tagResult.NotModified) {
+            $tagInfo = $tagResult.Data
+            if (Get-Member -InputObject $action -Name "tagInfo" -MemberType Properties) {
+                $action.tagInfo = $tagInfo
+            }
+            else {
+                $action | Add-Member -Name tagInfo -Value $tagInfo -MemberType NoteProperty
+            }
+            $tagInfoChanged = $true
         }
 
+        if ($tagResult.ETag) {
+            if ($existingTagEtagField) {
+                $action.tagInfoEtag = $tagResult.ETag
+            }
+            else {
+                $action | Add-Member -Name tagInfoEtag -Value $tagResult.ETag -MemberType NoteProperty
+            }
+        }
+
+        # Always bump the checked-at timestamp, even on a 304, so priority scoring
+        # (oldest tagInfoCheckedAt first) doesn't keep reselecting the same entries.
         if (Get-Member -InputObject $action -Name "tagInfoCheckedAt" -MemberType Properties) {
             $action.tagInfoCheckedAt = Get-Date
         }
@@ -138,15 +160,33 @@ function Update-VersionInfoForAction {
         }
     }
 
-    $releaseInfo = GetRepoReleases -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
-    if ($null -ne $releaseInfo) {
-        if (Get-Member -InputObject $action -Name "releaseInfo" -MemberType Properties) {
-            $action.releaseInfo = $releaseInfo
-        }
-        else {
-            $action | Add-Member -Name releaseInfo -Value $releaseInfo -MemberType NoteProperty
+    $existingReleaseEtagField = Get-Member -InputObject $action -Name "releaseInfoEtag" -MemberType Properties
+    $existingReleaseEtag = if ($existingReleaseEtagField) { $action.releaseInfoEtag } else { $null }
+    $releaseResult = GetRepoReleases -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime -etag $existingReleaseEtag
+    $releaseInfoChanged = $false
+    if ($null -ne $releaseResult) {
+        if (-not $releaseResult.NotModified) {
+            $releaseInfo = $releaseResult.Data
+            if (Get-Member -InputObject $action -Name "releaseInfo" -MemberType Properties) {
+                $action.releaseInfo = $releaseInfo
+            }
+            else {
+                $action | Add-Member -Name releaseInfo -Value $releaseInfo -MemberType NoteProperty
+            }
+            $releaseInfoChanged = $true
         }
 
+        if ($releaseResult.ETag) {
+            if ($existingReleaseEtagField) {
+                $action.releaseInfoEtag = $releaseResult.ETag
+            }
+            else {
+                $action | Add-Member -Name releaseInfoEtag -Value $releaseResult.ETag -MemberType NoteProperty
+            }
+        }
+
+        # Always bump the checked-at timestamp, even on a 304, so priority scoring
+        # (oldest releaseInfoCheckedAt first) doesn't keep reselecting the same entries.
         if (Get-Member -InputObject $action -Name "releaseInfoCheckedAt" -MemberType Properties) {
             $action.releaseInfoCheckedAt = Get-Date
         }
@@ -155,7 +195,7 @@ function Update-VersionInfoForAction {
         }
     }
 
-    return ($null -ne $tagInfo -or $null -ne $releaseInfo)
+    return ($tagInfoChanged -or $releaseInfoChanged)
 }
 
 function Run {

--- a/.github/workflows/repoInfo.ps1
+++ b/.github/workflows/repoInfo.ps1
@@ -396,11 +396,16 @@ function GetRepoInfo {
         [Parameter(Mandatory=$true)]
         [Alias('access_token')]
         $accessToken,
-        $startTime
+        $startTime,
+        # Previously stored ETag for this repo's metadata, if any. When provided, an
+        # unchanged repo comes back as a 304 Not Modified, which GitHub does not count
+        # against the core rate limit - so repeatedly re-checking already-known repos
+        # here is effectively free instead of costing a full API call each time.
+        $etag = $null
     )
 
     if ($null -eq $owner -or $owner.Length -eq 0) {
-        return ($null, $null, $null, $null, $null)
+        return ($null, $null, $null, $null, $null, $null, $false)
     }
 
     # Check if we are nearing the 50-minute mark
@@ -414,7 +419,7 @@ function GetRepoInfo {
     Write-Host "Loading repository info for [$owner/$repo]"
 
     # Treat 404s as expected (repo deleted or private) without flooding logs
-    $repoResponse = ApiCall -method GET -url $url -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken
+    $repoResponse = ApiCall -method GET -url $url -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken -etag $etag -returnETag $true
     if ($repoResponse -is [hashtable] -and $repoResponse.Error) {
         $statusCode = $null
         if ($repoResponse.StatusCode) {
@@ -436,12 +441,20 @@ function GetRepoInfo {
             Write-Host "Error loading repository info for [$owner/$repo]: StatusCode [$statusCode]"
         }
 
-        return ($null, $null, $null, $null, $statusCode)
+        return ($null, $null, $null, $null, $statusCode, $null, $false)
     }
 
-    if ($null -eq $repoResponse) {
-        return ($null, $null, $null, $null, $null)
+    if ($repoResponse -is [hashtable] -and $repoResponse.NotModified) {
+        Write-Host "Repository info for [$owner/$repo] is unchanged (304 Not Modified) - call was free, not counted against rate limit"
+        return ($null, $null, $null, $null, $null, $repoResponse.ETag, $true)
     }
+
+    if ($null -eq $repoResponse -or $null -eq $repoResponse.Data) {
+        return ($null, $null, $null, $null, $null, $null, $false)
+    }
+
+    $repoData = $repoResponse.Data
+    $newEtag = $repoResponse.ETag
 
     $releaseUrl = "/repos/$owner/$repo/releases/latest"
     $releaseResponse = ApiCall -method GET -url $releaseUrl -hideFailedCall $true -returnErrorInfo $true -access_token $accessToken
@@ -450,7 +463,7 @@ function GetRepoInfo {
         $latestReleaseDate = $releaseResponse.published_at
     }
 
-    return ($repoResponse.archived, $repoResponse.disabled, $repoResponse.updated_at, $latestReleaseDate, $null)
+    return ($repoData.archived, $repoData.disabled, $repoData.updated_at, $latestReleaseDate, $null, $newEtag, $false)
 }
 
 # GetRepoTagInfo and GetRepoReleases moved to library.ps1 so releaseInfo-refresh.ps1
@@ -1672,6 +1685,9 @@ function GetMoreInfo {
                 $repo_disabled = $null
                 $repo_updated_at = $null
                 $latest_release_published_at = $null
+                # Only ever set by the REST fallback path below (GraphQL has no ETag/304 concept here)
+                $repoNotModified = $false
+                $newRepoEtag = $null
 
                 $graphqlEntry = $null
                 if ($graphqlResultsByName.ContainsKey($action.name)) {
@@ -1703,8 +1719,12 @@ function GetMoreInfo {
                 }
                 else {
                     Write-Host "$i/$max - Checking extended action information for [$forkOrg/$($action.name)] via REST fallback. hasField: [$($null -ne $hasField)], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
+                    $existingRepoEtag = $null
+                    if ($hasField -and $action.repoInfo -and (Get-Member -InputObject $action.repoInfo -Name "etag" -MemberType Properties)) {
+                        $existingRepoEtag = $action.repoInfo.etag
+                    }
                     try {
-                        ($repo_archived, $repo_disabled, $repo_updated_at, $latest_release_published_at, $statusCode) = GetRepoInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
+                        ($repo_archived, $repo_disabled, $repo_updated_at, $latest_release_published_at, $statusCode, $newRepoEtag, $repoNotModified) = GetRepoInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime -etag $existingRepoEtag
                         if ($statusCode -and ($statusCode -eq "NotFound")) {
                             $action.upstreamFound = $false
                             # todo: remove this repo from the list (and push it back into the original actions list!)
@@ -1756,7 +1776,19 @@ function GetMoreInfo {
                     }
                 }
 
-                if ($repo_updated_at) {
+                if ($repoNotModified -and $hasField) {
+                    # 304 from the REST fallback: the repo hasn't changed since we last saw it, so
+                    # this call was free (not counted against the core rate limit). Only bump
+                    # lastFetched (and the ETag, in case GitHub rotated it) so priority scoring
+                    # doesn't keep reselecting this entry every run - don't touch the actual data.
+                    Write-Host "Repo information for [$($action.owner)/$($action.name)] is unchanged (304 Not Modified) - refreshing lastFetched only"
+                    $action.repoInfo | Add-Member -Name lastFetched -Value (Get-Date -Format 'o') -MemberType NoteProperty -Force
+                    if ($newRepoEtag) {
+                        $action.repoInfo | Add-Member -Name etag -Value $newRepoEtag -MemberType NoteProperty -Force
+                    }
+                    $memberUpdate++ | Out-Null
+                }
+                elseif ($repo_updated_at) {
                     if (!$hasField) {
                         Write-Host "Adding repo information object with archived:[$($repo_archived)], disabled:[$($repo_disabled)], updated_at:[$($repo_updated_at)], latest_release_published_at:[$($latest_release_published_at)] for [$($action.owner)/$($action.name)]"
                         $repoInfo = @{
@@ -1765,6 +1797,9 @@ function GetMoreInfo {
                             updated_at = $repo_updated_at
                             latest_release_published_at = $latest_release_published_at
                             lastFetched = (Get-Date -Format 'o')
+                        }
+                        if ($newRepoEtag) {
+                            $repoInfo.etag = $newRepoEtag
                         }
 
                         $action | Add-Member -Name repoInfo -Value $repoInfo -MemberType NoteProperty
@@ -1778,6 +1813,9 @@ function GetMoreInfo {
                         $action.repoInfo.updated_at = $repo_updated_at
                         $action.repoInfo.latest_release_published_at = $latest_release_published_at
                         $action.repoInfo | Add-Member -Name lastFetched -Value (Get-Date -Format 'o') -MemberType NoteProperty -Force
+                        if ($newRepoEtag) {
+                            $action.repoInfo | Add-Member -Name etag -Value $newRepoEtag -MemberType NoteProperty -Force
+                        }
                         $memberUpdate++ | Out-Null
                     }
                 }
@@ -1795,17 +1833,34 @@ function GetMoreInfo {
             }
             if (!$hasField -or ($null -eq $action.tagInfo) -or $tagInfoStale) {
                 #Write-Host "$i/$max - Checking tag information for [$forkOrg/$($action.name)]. hasField: [$hasField], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
+                $existingTagEtagField = Get-Member -inputobject $action -name "tagInfoEtag" -Membertype Properties
+                $existingTagEtag = if ($existingTagEtagField) { $action.tagInfoEtag } else { $null }
                 try {
-                    $tagInfo = GetRepoTagInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
-                    if (!$hasField) {
-                        Write-Host "Adding tag information object with tags:[$($tagInfo.Length)] for [$($owner)/$($repo)]"
-
-                        $action | Add-Member -Name tagInfo -Value $tagInfo -MemberType NoteProperty
-                        $i++ | Out-Null
+                    $tagResult = GetRepoTagInfo -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime -etag $existingTagEtag
+                    if ($tagResult.NotModified) {
+                        # Free call (304) - tags haven't changed, only refresh the checked-at timestamp
+                        # so staleness scoring doesn't keep reselecting this entry every run.
+                        Write-Host "Tags for [$owner/$repo] are unchanged (304 Not Modified)"
                     }
                     else {
-                        #Write-Host "Updating tag information object with tags:[$($tagInfo.Length)]"
-                        $action.tagInfo = $tagInfo
+                        $tagInfo = $tagResult.Data
+                        if (!$hasField) {
+                            Write-Host "Adding tag information object with tags:[$($tagInfo.Length)] for [$($owner)/$($repo)]"
+
+                            $action | Add-Member -Name tagInfo -Value $tagInfo -MemberType NoteProperty
+                            $i++ | Out-Null
+                        }
+                        else {
+                            #Write-Host "Updating tag information object with tags:[$($tagInfo.Length)]"
+                            $action.tagInfo = $tagInfo
+                        }
+                    }
+                    if ($tagResult.ETag) {
+                        if (!$existingTagEtagField) {
+                            $action | Add-Member -Name tagInfoEtag -Value $tagResult.ETag -MemberType NoteProperty
+                        } else {
+                            $action.tagInfoEtag = $tagResult.ETag
+                        }
                     }
                     if (!$tagInfoCheckedAtField) {
                         $action | Add-Member -Name tagInfoCheckedAt -Value (Get-Date) -MemberType NoteProperty
@@ -1851,17 +1906,34 @@ function GetMoreInfo {
             }
             if (!$hasField -or ($null -eq $action.releaseInfo) -or $releaseInfoStale) {
                 #Write-Host "$i/$max - Checking release information for [$forkOrg/$($action.name)]. hasField: [$hasField], actionType: [$($action.actionType.actionType)], updated_at: [$($action.repoInfo.updated_at)]"
+                $existingReleaseEtagField = Get-Member -inputobject $action -name "releaseInfoEtag" -Membertype Properties
+                $existingReleaseEtag = if ($existingReleaseEtagField) { $action.releaseInfoEtag } else { $null }
                 try {
-                    $releaseInfo = GetRepoReleases -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime
-                    if (!$hasField) {
-                        Write-Host "Adding release information object with releases:[$($releaseInfo.Length)] for [$($owner)/$($repo))]"
-
-                        $action | Add-Member -Name releaseInfo -Value $releaseInfo -MemberType NoteProperty
-                        $i++ | Out-Null
+                    $releaseResult = GetRepoReleases -owner $owner -repo $repo -accessToken $accessToken -startTime $startTime -etag $existingReleaseEtag
+                    if ($releaseResult.NotModified) {
+                        # Free call (304) - releases haven't changed, only refresh the checked-at timestamp
+                        # so staleness scoring doesn't keep reselecting this entry every run.
+                        Write-Host "Releases for [$owner/$repo] are unchanged (304 Not Modified)"
                     }
                     else {
-                        #Write-Host "Updating release information object with releases:[$($releaseInfo.Length)]"
-                        $action.releaseInfo = $releaseInfo
+                        $releaseInfo = $releaseResult.Data
+                        if (!$hasField) {
+                            Write-Host "Adding release information object with releases:[$($releaseInfo.Length)] for [$($owner)/$($repo))]"
+
+                            $action | Add-Member -Name releaseInfo -Value $releaseInfo -MemberType NoteProperty
+                            $i++ | Out-Null
+                        }
+                        else {
+                            #Write-Host "Updating release information object with releases:[$($releaseInfo.Length)]"
+                            $action.releaseInfo = $releaseInfo
+                        }
+                    }
+                    if ($releaseResult.ETag) {
+                        if (!$existingReleaseEtagField) {
+                            $action | Add-Member -Name releaseInfoEtag -Value $releaseResult.ETag -MemberType NoteProperty
+                        } else {
+                            $action.releaseInfoEtag = $releaseResult.ETag
+                        }
                     }
                     if (!$releaseInfoCheckedAtField) {
                         $action | Add-Member -Name releaseInfoCheckedAt -Value (Get-Date) -MemberType NoteProperty

--- a/tests/apiCallETag.Tests.ps1
+++ b/tests/apiCallETag.Tests.ps1
@@ -1,0 +1,152 @@
+BeforeAll {
+    # Import the library functions
+    . $PSScriptRoot/../.github/workflows/library.ps1
+}
+
+Describe "ApiCall Conditional Request (ETag) Tests" {
+    BeforeEach {
+        $global:RateLimitExceeded = $false
+    }
+
+    Context "Backward compatibility: callers that don't opt in are unaffected" {
+        BeforeAll {
+            Mock GetBasicAuthenticationHeader { return "Basic test" }
+            Mock Invoke-WebRequest {
+                return New-Object PSObject -Property @{
+                    StatusCode = 200
+                    Content    = '{"hello":"world"}'
+                    Headers    = @{ "ETag" = @('"abc123"') }
+                }
+            }
+        }
+
+        It "Should return the raw response body when -returnETag is not used" {
+            $result = ApiCall -method GET -url "some/endpoint" -access_token "test_token"
+            $result.hello | Should -Be "world"
+        }
+
+        It "Should not send an If-None-Match header when -etag is passed without -returnETag" {
+            $capturedHeaders = $null
+            Mock Invoke-WebRequest {
+                $script:capturedHeaders = $Headers
+                return New-Object PSObject -Property @{
+                    StatusCode = 200
+                    Content    = '{"hello":"world"}'
+                    Headers    = @{ "ETag" = @('"abc123"') }
+                }
+            }
+            ApiCall -method GET -url "some/endpoint" -access_token "test_token" -etag '"old-etag"' | Out-Null
+            $script:capturedHeaders.ContainsKey('If-None-Match') | Should -Be $false
+        }
+    }
+
+    Context "Successful request with -returnETag opted in" {
+        BeforeAll {
+            Mock GetBasicAuthenticationHeader { return "Basic test" }
+            $script:capturedHeaders = $null
+            Mock Invoke-WebRequest {
+                $script:capturedHeaders = $Headers
+                return New-Object PSObject -Property @{
+                    StatusCode = 200
+                    Content    = '{"hello":"world"}'
+                    Headers    = @{ "ETag" = @('"new-etag-value"') }
+                }
+            }
+        }
+
+        It "Should send If-None-Match when a previous ETag is supplied" {
+            ApiCall -method GET -url "some/endpoint" -access_token "test_token" -etag '"old-etag"' -returnETag $true | Out-Null
+            $script:capturedHeaders.ContainsKey('If-None-Match') | Should -Be $true
+            $script:capturedHeaders['If-None-Match'] | Should -Be '"old-etag"'
+        }
+
+        It "Should wrap the response with NotModified=false, the new ETag, and the body in Data" {
+            $result = ApiCall -method GET -url "some/endpoint" -access_token "test_token" -etag '"old-etag"' -returnETag $true
+            $result.NotModified | Should -Be $false
+            $result.ETag | Should -Be '"new-etag-value"'
+            $result.Data.hello | Should -Be "world"
+        }
+
+        It "Should not send If-None-Match on the very first call (no stored ETag yet)" {
+            ApiCall -method GET -url "some/endpoint" -access_token "test_token" -returnETag $true | Out-Null
+            $script:capturedHeaders.ContainsKey('If-None-Match') | Should -Be $false
+        }
+    }
+
+    Context "304 Not Modified response" {
+        BeforeAll {
+            Mock GetBasicAuthenticationHeader { return "Basic test" }
+            Mock Invoke-WebRequest {
+                $webResponse = New-Object PSObject -Property @{
+                    StatusCode = 304
+                    Headers    = @{}
+                }
+                $exception = New-Object System.Net.WebException("Not Modified")
+                $exception | Add-Member -NotePropertyName Response -NotePropertyValue $webResponse -Force
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    $exception,
+                    "WebException",
+                    [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                    $null
+                )
+                throw $errorRecord
+            }
+        }
+
+        It "Should return NotModified=true with the original ETag echoed back, and Data=null" {
+            $result = ApiCall -method GET -url "some/endpoint" -access_token "test_token" -etag '"unchanged-etag"' -returnETag $true
+            $result.NotModified | Should -Be $true
+            $result.ETag | Should -Be '"unchanged-etag"'
+            $result.Data | Should -Be $null
+        }
+
+        It "Should not set the global rate-limit-exceeded flag on a 304" {
+            ApiCall -method GET -url "some/endpoint" -access_token "test_token" -etag '"unchanged-etag"' -returnETag $true | Out-Null
+            $global:RateLimitExceeded | Should -Be $false
+        }
+
+        It "Should not retry (only call Invoke-WebRequest once) on a 304" {
+            ApiCall -method GET -url "some/endpoint" -access_token "test_token" -etag '"unchanged-etag"' -returnETag $true | Out-Null
+            Assert-MockCalled Invoke-WebRequest -Times 1
+        }
+    }
+
+    Context "GetRepoTagInfo and GetRepoReleases conditional request wiring" {
+        BeforeAll {
+            Mock GetBasicAuthenticationHeader { return "Basic test" }
+        }
+
+        It "GetRepoTagInfo should return NotModified=true and Data=null on a 304" {
+            Mock Invoke-WebRequest {
+                $webResponse = New-Object PSObject -Property @{
+                    StatusCode = 304
+                    Headers    = @{}
+                }
+                $exception = New-Object System.Net.WebException("Not Modified")
+                $exception | Add-Member -NotePropertyName Response -NotePropertyValue $webResponse -Force
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    $exception, "WebException", [System.Management.Automation.ErrorCategory]::InvalidOperation, $null
+                )
+                throw $errorRecord
+            }
+            $result = GetRepoTagInfo -owner "octo" -repo "hello" -accessToken "token" -startTime (Get-Date) -etag '"tags-etag"'
+            $result.NotModified | Should -Be $true
+            $result.Data | Should -Be $null
+        }
+
+        It "GetRepoReleases should return the parsed release array and a new ETag on 200" {
+            Mock Invoke-WebRequest {
+                return New-Object PSObject -Property @{
+                    StatusCode = 200
+                    Content    = '[{"tag_name":"v1.0.0","target_commitish":"main"}]'
+                    Headers    = @{ "ETag" = @('"releases-etag"') }
+                }
+            }
+            $result = GetRepoReleases -owner "octo" -repo "hello" -accessToken "token" -startTime (Get-Date) -etag $null
+            $result.NotModified | Should -Be $false
+            $result.ETag | Should -Be '"releases-etag"'
+            $firstRelease = @($result.Data)[0]
+            $firstRelease.tag_name | Should -Be "v1.0.0"
+        }
+    }
+}


### PR DESCRIPTION
## Why

GitHub does **not** count `304 Not Modified` responses against the core REST rate limit. Today, `ApiCall` in `library.ps1` logs rate-limit headers (there was a `# todo: check and handle the rate limit headers` comment) but never sends `If-None-Match`, so every repeated "did anything change?" check for one of the ~29k tracked actions costs a full API call, even when nothing changed since the last run (the overwhelming majority of the time).

This PR adds opt-in conditional-request support to `ApiCall` and wires it into the REST call sites that repeatedly re-check the same resource on an hourly cadence.

## Scope, given PR #249 and #250

PR #249 replaced most of `repoInfo.ps1`'s per-repo REST metadata fetch with a GraphQL batch (`Invoke-GraphQLRepoMetadataBatch`), and PR #250 added a zero-cost skip + cached mirror SHA to `update-mirrors.ps1`. Neither of those touches REST conditional requests, and GraphQL doesn't have an ETag/304 concept the way REST does, so this PR is scoped to the REST call sites that remain:

- **`GetRepoInfo`** in `repoInfo.ps1` - the REST fallback path used when a repo isn't covered by the GraphQL batch (`repos/$owner/$repo`).
- **`GetRepoTagInfo`** / **`GetRepoReleases`** in `library.ps1` - shared by both `repoInfo.ps1` and `releaseInfo-refresh.ps1` (`.../git/matching-refs/tags` and `.../releases`), which is the highest-volume remaining REST hot path since `releaseInfo-refresh.ps1` exists specifically to re-check tags/releases for already-known, already-mirrored actions every run.

## What changed

**`ApiCall` (`library.ps1`)**
- New optional params: `-etag` (a previously stored ETag to send as `If-None-Match`) and `-returnETag` (opt-in switch). Existing callers that don't pass `-returnETag` get the exact same raw response as before - fully backward compatible.
- When `-returnETag` is set, a successful response is wrapped as `@{ NotModified = $false; ETag = <new etag>; Data = <body> }`.
- A `304` is caught right at the top of the `catch` block - before any of the retry/rate-limit/app-rotation/error-logging logic - since it isn't an error and must never be retried or counted as a failure. It returns `@{ NotModified = $true; ETag = <etag we sent>; Data = $null }`.
- All 13 recursive retry/rotation call sites inside `ApiCall` (token expiry rotation, rate-limit app switching, backoff retries) propagate `-etag`/`-returnETag` so a retry mid-flight preserves the conditional-request behavior. The one exception is the pagination continuation call, which intentionally does *not* forward these, since wrapping would break the existing array-accumulation logic across pages.

**`repoInfo.ps1`**
- `GetRepoInfo` now accepts `-etag`, sends it, and returns the new ETag + a `NotModified` flag alongside the existing tuple.
- The REST-fallback call site stores the ETag as `action.repoInfo.etag`. On a 304, only `lastFetched` (and the ETag, in case GitHub rotated it) is refreshed - the actual `archived`/`disabled`/`updated_at`/`latest_release_published_at` fields are left untouched.
- Same pattern for the `tagInfo`/`releaseInfo` blocks: new `action.tagInfoEtag` / `action.releaseInfoEtag` fields, `tagInfoCheckedAt`/`releaseInfoCheckedAt` still advance on a 304 so the staleness-based priority scoring doesn't keep reselecting the same entries forever.

**`releaseInfo-refresh.ps1`**
- `Update-VersionInfoForAction` now sends the stored `tagInfoEtag`/`releaseInfoEtag` and only overwrites `tagInfo`/`releaseInfo` when the data actually changed, while still always advancing the checked-at timestamps on a 304 (this script's entire purpose is a freshness-ordered revisit queue, so this matters a lot here).

**`status.json` schema**
- All new fields (`repoInfo.etag`, `tagInfoEtag`, `releaseInfoEtag`) are additive/optional. `validate-status-schema.ps1`'s schema class uses loosely-typed `[object]` fields and doesn't reject unknown properties, so no changes were needed there.

**Tests**
- Added `tests/apiCallETag.Tests.ps1` (10 tests): backward-compatibility when `-returnETag` isn't used, `If-None-Match` header behavior (including "no header on the very first call"), the wrapped 200 response shape, the 304 path (including "does not retry, does not set the rate-limit-exceeded flag"), and `GetRepoTagInfo`/`GetRepoReleases` wiring.

## Testing

- `Invoke-Pester -Path tests/apiCallETag.Tests.ps1` - 10/10 passing.
- Full suite (`Invoke-Pester -Path tests`) - 732 passed, 2 failed, 3 skipped. Confirmed via `git stash` that the same 2 failures (`Select-ForksToProcess... recent repeated failures` and `Trivy Container Scan Logic... 7 days`) exist identically on `main` before this change - pre-existing and unrelated.
- Verified all three modified `.ps1` files parse cleanly via `[System.Management.Automation.Language.Parser]::ParseFile`.